### PR TITLE
Validate before state update

### DIFF
--- a/programs/marginfi/src/state/bank.rs
+++ b/programs/marginfi/src/state/bank.rs
@@ -432,13 +432,12 @@ impl BankImpl for Bank {
         bypass_deposit_limit: bool,
     ) -> MarginfiResult {
         let total_asset_shares: I80F48 = self.total_asset_shares.into();
-        self.total_asset_shares = total_asset_shares
+        let new_total_shares = total_asset_shares
             .checked_add(shares)
-            .ok_or_else(math_error!())?
-            .into();
+            .ok_or_else(math_error!())?;
 
         if shares.is_positive() && self.config.is_deposit_limit_active() && !bypass_deposit_limit {
-            let total_deposits_amount = self.get_asset_amount(self.total_asset_shares.into())?;
+            let total_deposits_amount = self.get_asset_amount(new_total_shares)?;
 
             // For Drift banks, deposit_limit is in native decimals but total_deposits_amount
             // is in 9-decimal (DRIFT_SCALED_BALANCE_DECIMALS). We Scale deposit_limit to match.
@@ -455,6 +454,8 @@ impl BankImpl for Bank {
                 return err!(MarginfiError::BankAssetCapacityExceeded);
             }
         }
+
+        self.total_asset_shares = new_total_shares.into();
 
         Ok(())
     }


### PR DESCRIPTION
## Description

Defers the `total_asset_shares` update until deposit limit validation succeeds, following a compute → validate → commit flow and avoiding premature state mutation.

## Changes

- Compute `new_total_shares` without immediately updating `total_asset_shares`.
- Validate deposit limits using `new_total_shares`.
- Commit `total_asset_shares` only after all validations pass.
- No functional changes to deposit limit enforcement or accounting logic.