### PR TITLE
Variable Borrow Rate fixes

### DIFF
--- a/programs/marginfi/src/instructions/drift/withdraw.rs
+++ b/programs/marginfi/src/instructions/drift/withdraw.rs
@@ -300,6 +300,7 @@ pub fn drift_withdraw<'info>(
                 &group,
                 &premium_scratch,
                 clock.unix_timestamp as u64,
+                true,
             )?;
 
             {

--- a/programs/marginfi/src/instructions/juplend/withdraw.rs
+++ b/programs/marginfi/src/instructions/juplend/withdraw.rs
@@ -310,6 +310,7 @@ pub fn juplend_withdraw<'info>(
                 &group,
                 &premium_scratch,
                 clock.unix_timestamp as u64,
+                true,
             )?;
 
             {

--- a/programs/marginfi/src/instructions/kamino/withdraw.rs
+++ b/programs/marginfi/src/instructions/kamino/withdraw.rs
@@ -267,6 +267,7 @@ pub fn kamino_withdraw<'info>(
             &group,
             &premium_scratch,
             clock.unix_timestamp as u64,
+            true,
         )?;
 
         {

--- a/programs/marginfi/src/instructions/marginfi_account/borrow.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/borrow.rs
@@ -234,11 +234,14 @@ pub fn lending_account_borrow<'info>(
     run_cb_price_gate(&marginfi_account, ctx.remaining_accounts)?;
 
     // Claim premium at the old rates and refresh every liability's premium rate snapshot with
-    // the post-borrow collateral mix.
+    // the post-borrow collateral mix. Ratchet on incomplete is unreachable today (the gate
+    // above reverts first) — `true` is defense-in-depth so this owner-signed path can never
+    // regress to a rate freeze if that gate is ever relaxed.
     marginfi_account.update_premium_snapshots(
         &group,
         &premium_scratch,
         clock.unix_timestamp as u64,
+        true,
     )?;
 
     let bank_pk = ctx.accounts.bank.key();

--- a/programs/marginfi/src/instructions/marginfi_account/flashloan.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/flashloan.rs
@@ -139,11 +139,14 @@ pub fn lending_account_end_flashloan<'info>(
     );
 
     // Claim premium at the old rates and refresh every liability's premium rate snapshot with
-    // the post-flashloan balances.
+    // the post-flashloan balances. Ratchet on incomplete is unreachable today (the gate above
+    // reverts first) — `true` is defense-in-depth so this owner-signed path can never regress
+    // to a rate freeze if that gate is ever relaxed.
     marginfi_account.update_premium_snapshots(
         &group,
         &premium_scratch,
         Clock::get()?.unix_timestamp as u64,
+        true,
     )?;
 
     if marginfi_account.lending_account.has_liabilities() {

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
@@ -397,8 +397,22 @@ pub fn lending_account_liquidate<'info>(
                 .bank
                 .get_asset_amount(bank_account.balance.asset_shares.into())?;
 
+            // The seized value is vault-backed (the liquidatee's burned deposit tokens stay
+            // in the liquidity vault), so if the liquidator carries premium-active debt in
+            // this bank the credit settles premium FIRST, exactly like a repay. Without this,
+            // a credit that closes the principal would write the receivable off (the
+            // token-less flip rule) and the liquidator would escape accrued premium entirely
+            // — cheaply exploitable via self-liquidation between two accounts.
+            bank_account.claim_premium()?;
+            let premium_settled = bank_account.settle_premium(asset_amount)?;
+            let credit_amount = asset_amount
+                .checked_sub(premium_settled)
+                .ok_or_else(math_error!())?;
+
             // Liquidator will repay the debt (if any) and then deposit the remainder (if any).
-            bank_account.deposit_ignore_deposit_cap(asset_amount)?;
+            if credit_amount > I80F48::ZERO {
+                bank_account.deposit_ignore_deposit_cap(credit_amount)?;
+            }
 
             let post_balance: I80F48 = bank_account
                 .bank

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
@@ -598,7 +598,7 @@ fn check_liquidatee_health_and_refresh_premium<'info>(
         pre_liquidation_health,
         &mut Some(&mut premium_scratch),
     )?;
-    liquidatee_marginfi_account.update_premium_snapshots(group, &premium_scratch, now)?;
+    liquidatee_marginfi_account.update_premium_snapshots(group, &premium_scratch, now, false)?;
     Ok(post_liquidation_health)
 }
 
@@ -637,7 +637,7 @@ fn check_liquidator_health_and_refresh_premium<'info>(
         &mut None,
         &mut Some(&mut premium_scratch),
     )?;
-    liquidator_marginfi_account.update_premium_snapshots(group, &premium_scratch, now)?;
+    liquidator_marginfi_account.update_premium_snapshots(group, &premium_scratch, now, false)?;
 
     if !premium_scratch.complete && liab_info.premium_active {
         let balance = liquidator_marginfi_account

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate_end.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate_end.rs
@@ -158,6 +158,7 @@ pub fn end_receivership<'info>(
         group,
         &premium_scratch,
         Clock::get()?.unix_timestamp as u64,
+        false,
     )?;
 
     // health must not get worse

--- a/programs/marginfi/src/instructions/marginfi_account/order.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/order.rs
@@ -528,6 +528,7 @@ pub fn end_execute_order<'info>(ctx: Context<'info, EndExecuteOrder<'info>>) -> 
         &group,
         &premium_scratch,
         Clock::get()?.unix_timestamp as u64,
+        false,
     )?;
 
     marginfi_account.unset_flag(ACCOUNT_IN_ORDER_EXECUTION, false);

--- a/programs/marginfi/src/instructions/marginfi_account/pulse_health.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/pulse_health.rs
@@ -58,6 +58,7 @@ pub fn lending_account_pulse_health<'info>(
         &group,
         &premium_scratch,
         clock.unix_timestamp as u64,
+        false,
     )?;
 
     match engine_result {

--- a/programs/marginfi/src/instructions/marginfi_account/rebalance.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/rebalance.rs
@@ -1202,7 +1202,7 @@ fn check_rebalance_health_and_refresh_premium<'info>(
         &mut Some(health_cache),
         &mut Some(&mut premium_scratch),
     )?;
-    account.update_premium_snapshots(group, &premium_scratch, now)
+    account.update_premium_snapshots(group, &premium_scratch, now, false)
 }
 
 #[derive(Accounts)]

--- a/programs/marginfi/src/instructions/marginfi_account/withdraw.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/withdraw.rs
@@ -259,6 +259,7 @@ pub fn lending_account_withdraw<'info>(
             &group,
             &premium_scratch,
             clock.unix_timestamp as u64,
+            true,
         )?;
     }
 

--- a/programs/marginfi/src/instructions/solend/withdraw.rs
+++ b/programs/marginfi/src/instructions/solend/withdraw.rs
@@ -279,6 +279,7 @@ pub fn solend_withdraw<'info>(
                     &group,
                     &premium_scratch,
                     Clock::get()?.unix_timestamp as u64,
+                    true,
                 )?;
             }
 

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -7,6 +7,7 @@ use crate::{
     state::premium::{
         accrued_premium_total, premium_elapsed_seconds, BalancePremiumImpl, PremiumScratch,
         PremiumScratchEntry, SCRATCH_ASSET, SCRATCH_LIABILITY, SCRATCH_PREMIUM_ACTIVE,
+        SCRATCH_UNPRICEABLE,
     },
     utils::{is_integration_asset_tag, NumTraitsWithTolerance},
 };
@@ -626,6 +627,7 @@ fn collect_premium_scratch_entry(
     bank: &Bank,
     premium_price: I80F48,
     balance_index: usize,
+    unpriceable: bool,
 ) -> MarginfiResult {
     match balance.get_side() {
         Some(BalanceSide::Assets) => {
@@ -641,12 +643,16 @@ fn collect_premium_scratch_entry(
             } else {
                 I80F48::ZERO
             };
+            let mut flags = SCRATCH_ASSET;
+            if unpriceable {
+                flags |= SCRATCH_UNPRICEABLE;
+            }
             scratch.push(PremiumScratchEntry {
                 value: usd_value,
                 activated_at: 0,
                 premium_tag: bank.premium_tag,
                 balance_index: balance_index as u8,
-                flags: SCRATCH_ASSET,
+                flags,
             });
         }
         Some(BalanceSide::Liabilities) => {
@@ -1116,7 +1122,7 @@ pub fn get_health_components<'info>(
             get_remaining_accounts_per_bank(&bank)?
         };
 
-        let (asset_val, liab_val, price, err_code, premium_price) = if is_cached {
+        let (asset_val, liab_val, price, err_code, premium_price, leg_unpriceable) = if is_cached {
             let (asset_val, liab_val, price) = calc_weighted_value_cached_for_balance(
                 balance,
                 &bank,
@@ -1124,7 +1130,7 @@ pub fn get_health_components<'info>(
                 &reconciled_emode_config,
             )?;
             // Premium weights reuse the biased health price, same as the live branch.
-            (asset_val, liab_val, price, 0, price)
+            (asset_val, liab_val, price, 0, price, false)
         } else {
             // Load oracle (this is the heap-intensive operation)
             let oracle_ai_idx = account_index + 1;
@@ -1153,8 +1159,11 @@ pub fn get_health_components<'info>(
             // A countable collateral leg the premium weighting cannot price. The health pass
             // may not flag this itself (ReduceOnly + Initial soft-zeroes; stale-skip only
             // sets err_code), so mark the scratch directly — an incomplete pass must never
-            // write rates.
-            if need_premium_price && price_adapter_result.is_err() {
+            // plainly write rates (the withdraw paths ratchet instead). Zero-weight legs
+            // (`need_premium_price == false`) can't affect the mix, so their broken oracle
+            // doesn't taint the pass.
+            let leg_unpriceable = need_premium_price && price_adapter_result.is_err();
+            if leg_unpriceable {
                 if let Some(scratch) = premium_scratch.as_mut() {
                     scratch.unpriceable_leg = true;
                 }
@@ -1173,16 +1182,25 @@ pub fn get_health_components<'info>(
             }
 
             // Calculate weighted value for this position
-            calc_weighted_value_for_balance(
-                balance,
-                &bank,
-                &price_adapter_result,
-                requirement_type,
-                &reconciled_emode_config,
-                &mut liq_cache,
-                position_index,
-                need_premium_price,
-            )?
+            let (asset_val, liab_val, price, err_code, premium_price) =
+                calc_weighted_value_for_balance(
+                    balance,
+                    &bank,
+                    &price_adapter_result,
+                    requirement_type,
+                    &reconciled_emode_config,
+                    &mut liq_cache,
+                    position_index,
+                    need_premium_price,
+                )?;
+            (
+                asset_val,
+                liab_val,
+                price,
+                err_code,
+                premium_price,
+                leg_unpriceable,
+            )
         };
 
         // Record error index if applicable
@@ -1206,7 +1224,14 @@ pub fn get_health_components<'info>(
         let liab_premium_val =
             calc_premium_liab_value(balance, &bank, requirement_type, price, now)?;
         if let Some(scratch) = premium_scratch.as_mut() {
-            collect_premium_scratch_entry(scratch, balance, &bank, premium_price, balance_index)?;
+            collect_premium_scratch_entry(
+                scratch,
+                balance,
+                &bank,
+                premium_price,
+                balance_index,
+                leg_unpriceable,
+            )?;
         }
 
         debug!(

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -633,6 +633,7 @@ fn collect_premium_scratch_entry(
         Some(BalanceSide::Assets) => {
             let usd_value = if premium_price > I80F48::ZERO
                 && !matches!(bank.config.risk_tier, RiskTier::Isolated)
+                && I80F48::from(bank.config.asset_weight_maint) > I80F48::ZERO
             {
                 calc_value(
                     bank.get_asset_amount(balance.asset_shares.into())?,
@@ -1154,7 +1155,8 @@ pub fn get_health_components<'info>(
             let need_premium_price = premium_scratch.is_some()
                 && price_for_premium
                 && matches!(balance.get_side(), Some(BalanceSide::Assets))
-                && !matches!(bank.config.risk_tier, RiskTier::Isolated);
+                && !matches!(bank.config.risk_tier, RiskTier::Isolated)
+                && I80F48::from(bank.config.asset_weight_maint) > I80F48::ZERO;
 
             // A countable collateral leg the premium weighting cannot price. The health pass
             // may not flag this itself (ReduceOnly + Initial soft-zeroes; stale-skip only
@@ -2609,12 +2611,13 @@ impl<'a> BankAccountWrapper<'a> {
         // Below EMPTY_BALANCE_THRESHOLD health treats the liability as empty, so clear the
         // premium too — otherwise a book-transfer that leaves dust (liquidation) strands a
         // receivable that health never projects.
-        // INVARIANT: any reachable state where this fires during liquidation must revert
-        // upstream — `check_post_liquidation_conditions` rejects a fully-closed liability with
-        // `ExhaustedLiability` via the SAME `Balance::is_empty` predicate, which is what makes
-        // this write-off safe (it can only commit where the receivable was already settled or
-        // legitimately forgiven). If full close ever becomes legal in liquidation, premium must
-        // settle first — receivership's `repay_all` path is the model.
+        // INVARIANT: every liquidation path that can close a liability settles premium BEFORE
+        // this fires. The liquidatee's liab_bank leg cannot close (`ExhaustedLiability` uses
+        // the SAME `Balance::is_empty` predicate); the LIQUIDATOR's asset_bank leg — the one
+        // reachable full close — settles via `settle_premium` in `lending_account_liquidate`
+        // before the credit lands here; receivership's `repay_all` settles likewise. So this
+        // write-off only ever clears a receivable that was already settled or legitimately
+        // forgiven (bankruptcy / tokenless repayment / asset-side flips).
         if had_liabs && balance.is_empty(BalanceSide::Liabilities) {
             balance.write_off_premium();
         }

--- a/programs/marginfi/src/state/premium.rs
+++ b/programs/marginfi/src/state/premium.rs
@@ -281,15 +281,16 @@ pub trait MarginfiAccountPremiumImpl {
     /// The weighted rate for a liability is
     /// `Σ(collateral_usd_i × pair_rate(collateral_tag_i, liability_tag)) / Σ(collateral_usd_i)`,
     /// or zero when the account has no priced collateral or the matrix is disabled.
-    /// * No-op when the scratch is incomplete (partial health pass must never write rates).
-    /// `ratchet_on_incomplete`: with `false`, an incomplete pass is a no-op. With `true`, an
-    /// INCOMPLETE pass ratchets instead: each snapshot is rewritten to
-    /// `max(previous, weighted rate of the priceable collateral, highest pair rate among
-    /// unpriceable legs)` — it can only ever move UP. This closes the dilute-then-supply-a-bad-
-    /// oracle rate freeze without blocking the action itself.
-    /// * Pass `true` ONLY from authority-signed handlers (the five withdraw paths). On a
-    ///   permissionless surface (pulse, liquidation, order/rebalance end) a hostile caller
-    ///   could feed a bad oracle and ratchet a victim's rate — those must pass `false`.
+    ///
+    /// `ratchet_on_incomplete`: with `false`, an incomplete pass is a no-op (a partial health
+    /// pass must never write plain rates). With `true`, an incomplete pass ratchets instead:
+    /// each snapshot is rewritten to `max(previous, weighted rate of the priceable collateral,
+    /// highest pair rate among unpriceable legs)` — it can only ever move UP. This closes the
+    /// dilute-then-supply-a-bad-oracle rate freeze without blocking the action itself.
+    /// * Pass `true` ONLY from authority-signed handlers (the five withdraw paths and the
+    ///   gate-guarded borrow/flashloan-end). On a permissionless surface (pulse, liquidation,
+    ///   order/rebalance end) a hostile caller could feed a bad oracle and ratchet a victim's
+    ///   rate — those must pass `false`.
     fn update_premium_snapshots(
         &mut self,
         group: &MarginfiGroup,

--- a/programs/marginfi/src/state/premium.rs
+++ b/programs/marginfi/src/state/premium.rs
@@ -70,6 +70,10 @@ pub const SCRATCH_ASSET: u8 = 1 << 0;
 pub const SCRATCH_LIABILITY: u8 = 1 << 1;
 /// `PremiumScratchEntry.flags`: the liability's bank has `PREMIUM_ACTIVE` set.
 pub const SCRATCH_PREMIUM_ACTIVE: u8 = 1 << 2;
+/// `PremiumScratchEntry.flags`: a collateral leg whose premium price could not be derived
+/// (oracle adapter error, e.g. a caller-supplied wrong oracle account). Recorded with value 0;
+/// the ratchet fallback prices it punitively at its full configured pair rate.
+pub const SCRATCH_UNPRICEABLE: u8 = 1 << 3;
 
 /// Per-balance data collected during the health-check loop, enough to recompute premium
 /// snapshots afterwards without reloading banks or oracles.
@@ -104,6 +108,9 @@ impl PremiumScratchEntry {
     }
     pub fn is_premium_active(&self) -> bool {
         self.flags & SCRATCH_PREMIUM_ACTIVE != 0
+    }
+    pub fn is_unpriceable(&self) -> bool {
+        self.flags & SCRATCH_UNPRICEABLE != 0
     }
 }
 
@@ -269,11 +276,20 @@ pub trait MarginfiAccountPremiumImpl {
     /// `Σ(collateral_usd_i × pair_rate(collateral_tag_i, liability_tag)) / Σ(collateral_usd_i)`,
     /// or zero when the account has no priced collateral or the matrix is disabled.
     /// * No-op when the scratch is incomplete (partial health pass must never write rates).
+    /// `ratchet_on_incomplete`: with `false`, an incomplete pass is a no-op. With `true`, an
+    /// INCOMPLETE pass ratchets instead: each snapshot is rewritten to
+    /// `max(previous, weighted rate of the priceable collateral, highest pair rate among
+    /// unpriceable legs)` — it can only ever move UP. This closes the dilute-then-supply-a-bad-
+    /// oracle rate freeze without blocking the action itself.
+    /// * Pass `true` ONLY from authority-signed handlers (the five withdraw paths). On a
+    ///   permissionless surface (pulse, liquidation, order/rebalance end) a hostile caller
+    ///   could feed a bad oracle and ratchet a victim's rate — those must pass `false`.
     fn update_premium_snapshots(
         &mut self,
         group: &MarginfiGroup,
         scratch: &PremiumScratch,
         now: u64,
+        ratchet_on_incomplete: bool,
     ) -> MarginfiResult;
 }
 
@@ -283,8 +299,9 @@ impl MarginfiAccountPremiumImpl for MarginfiAccount {
         group: &MarginfiGroup,
         scratch: &PremiumScratch,
         now: u64,
+        ratchet_on_incomplete: bool,
     ) -> MarginfiResult {
-        update_premium_snapshots_internal(self, group, scratch, now)
+        update_premium_snapshots_internal(self, group, scratch, now, ratchet_on_incomplete)
     }
 }
 
@@ -293,10 +310,14 @@ fn update_premium_snapshots_internal(
     group: &MarginfiGroup,
     scratch: &PremiumScratch,
     now: u64,
+    ratchet_on_incomplete: bool,
 ) -> MarginfiResult {
-    if !scratch.complete {
+    if !scratch.complete && !ratchet_on_incomplete {
         return Ok(());
     }
+    // Unpriceable legs were recorded with value 0, so on an incomplete pass
+    // `total_collateral_usd` naturally spans exactly the priceable collateral.
+    let ratcheting = !scratch.complete;
 
     let entries = &scratch.entries[..scratch.count];
 
@@ -367,6 +388,24 @@ fn update_premium_snapshots_internal(
             marginfi_type_crate::types::milli_to_u32(rate)
         } else {
             0
+        };
+
+        // Ratchet: an incomplete pass may never LOWER a rate (that is the dilute-then-break-
+        // the-oracle freeze), and every unpriceable leg is priced punitively at its full pair
+        // rate. Forward-only: the claim above already billed the elapsed window at the old
+        // rate, and the next clean refresh recomputes freely (down included).
+        // The milli encoding is monotone, so `u32::max` is rate-max.
+        let new_rate = if ratcheting {
+            let mut floor = new_rate.max(balance.premium_rate_snapshot);
+            for collateral in entries {
+                if collateral.is_asset() && collateral.is_unpriceable() {
+                    floor =
+                        floor.max(group.find_premium_rate(collateral.premium_tag, liability_tag));
+                }
+            }
+            floor
+        } else {
+            new_rate
         };
 
         balance.premium_rate_snapshot = new_rate;
@@ -598,7 +637,7 @@ mod tests {
         scratch.complete = true;
 
         account
-            .update_premium_snapshots(&group, &scratch, 1_000)
+            .update_premium_snapshots(&group, &scratch, 1_000, false)
             .unwrap();
         assert_approx(snapshot_rate(&account), I80F48!(0.01), TOL);
         // 0 -> nonzero transition bumped the accrual clock (no retroactive projection)
@@ -607,6 +646,121 @@ mod tests {
             I80F48::from(account.lending_account.balances[0].premium_outstanding),
             I80F48::ZERO
         );
+    }
+
+    // ---------------- ratchet fallback (incomplete pass, withdraw paths) ----------------
+
+    fn unpriceable_entry(tag: u16) -> PremiumScratchEntry {
+        PremiumScratchEntry {
+            value: I80F48::ZERO,
+            activated_at: 0,
+            premium_tag: tag,
+            balance_index: 0,
+            flags: SCRATCH_ASSET | SCRATCH_UNPRICEABLE,
+        }
+    }
+
+    #[test]
+    fn ratchet_incomplete_takes_max_of_prev_known_and_unpriceable_pair() {
+        // prev 3%; the only priced collateral is untagged (known 0%); the unpriceable leg's
+        // pair is 4% -> ratchet writes 4%. The plain refresh must stay a no-op.
+        let group = group_with(&[(100, 200, 4.0)]);
+        let liab_pk = Pubkey::new_unique();
+        let mut account = account_with_liability(liab_pk, rate(3.0), 500);
+
+        let mut scratch = PremiumScratch::default();
+        scratch.push(asset_entry(1_000.0, 0));
+        scratch.push(unpriceable_entry(100));
+        scratch.push(liab_entry(0, 50.0, 200));
+        scratch.complete = false;
+        scratch.unpriceable_leg = true;
+
+        account
+            .update_premium_snapshots(&group, &scratch, 1_000, false)
+            .unwrap();
+        assert_approx(snapshot_rate(&account), I80F48!(0.03), TOL);
+        assert_eq!(account.lending_account.balances[0].last_update, 500);
+
+        account
+            .update_premium_snapshots(&group, &scratch, 1_000, true)
+            .unwrap();
+        assert_approx(snapshot_rate(&account), I80F48!(0.04), TOL);
+        // The elapsed 500s were claimed at the OLD 3% (punitive rate is forward-only).
+        assert_eq!(account.lending_account.balances[0].last_update, 1_000);
+        let expected_claim = I80F48!(50)
+            .checked_mul(I80F48!(0.03))
+            .unwrap()
+            .checked_mul(
+                I80F48::from_num(500u64)
+                    .checked_div(SECONDS_PER_YEAR)
+                    .unwrap(),
+            )
+            .unwrap();
+        assert_approx(
+            I80F48::from(account.lending_account.balances[0].premium_outstanding),
+            expected_claim,
+            TOL,
+        );
+    }
+
+    #[test]
+    fn ratchet_never_lowers_below_previous_snapshot() {
+        // prev 9% beats both the priced average (6%) and the unpriceable pair (4%).
+        let group = group_with(&[(100, 200, 4.0), (300, 200, 6.0)]);
+        let liab_pk = Pubkey::new_unique();
+        let mut account = account_with_liability(liab_pk, rate(9.0), 500);
+
+        let mut scratch = PremiumScratch::default();
+        scratch.push(asset_entry(1_000.0, 300));
+        scratch.push(unpriceable_entry(100));
+        scratch.push(liab_entry(0, 50.0, 200));
+        scratch.complete = false;
+        scratch.unpriceable_leg = true;
+
+        account
+            .update_premium_snapshots(&group, &scratch, 1_000, true)
+            .unwrap();
+        assert_approx(snapshot_rate(&account), I80F48!(0.09), TOL);
+    }
+
+    #[test]
+    fn ratchet_takes_priced_average_when_it_is_highest() {
+        // Priced tagged collateral averages 6% > prev 3% > unpriceable pair 4%... max = 6%.
+        let group = group_with(&[(100, 200, 4.0), (300, 200, 6.0)]);
+        let liab_pk = Pubkey::new_unique();
+        let mut account = account_with_liability(liab_pk, rate(3.0), 500);
+
+        let mut scratch = PremiumScratch::default();
+        scratch.push(asset_entry(1_000.0, 300));
+        scratch.push(unpriceable_entry(100));
+        scratch.push(liab_entry(0, 50.0, 200));
+        scratch.complete = false;
+        scratch.unpriceable_leg = true;
+
+        account
+            .update_premium_snapshots(&group, &scratch, 1_000, true)
+            .unwrap();
+        assert_approx(snapshot_rate(&account), I80F48!(0.06), TOL);
+    }
+
+    #[test]
+    fn ratchet_on_complete_pass_recomputes_freely_down() {
+        // A complete pass through the ratchet entrypoint behaves exactly like the plain
+        // refresh — it may LOWER the rate.
+        let group = group_with(&[(100, 200, 1.0)]);
+        let liab_pk = Pubkey::new_unique();
+        let mut account = account_with_liability(liab_pk, rate(5.0), 500);
+
+        let mut scratch = PremiumScratch::default();
+        scratch.push(asset_entry(500.0, 100));
+        scratch.push(asset_entry(500.0, 0));
+        scratch.push(liab_entry(0, 50.0, 200));
+        scratch.complete = true;
+
+        account
+            .update_premium_snapshots(&group, &scratch, 1_000, true)
+            .unwrap();
+        assert_approx(snapshot_rate(&account), I80F48!(0.005), TOL);
     }
 
     #[test]
@@ -623,7 +777,7 @@ mod tests {
         scratch.complete = true;
 
         account
-            .update_premium_snapshots(&group, &scratch, 1_000)
+            .update_premium_snapshots(&group, &scratch, 1_000, false)
             .unwrap();
         assert_approx(snapshot_rate(&account), I80F48!(0.002), TOL);
     }
@@ -662,7 +816,7 @@ mod tests {
         scratch.complete = true;
 
         account
-            .update_premium_snapshots(&group, &scratch, 1_000)
+            .update_premium_snapshots(&group, &scratch, 1_000, false)
             .unwrap();
 
         let rate_of = |i: usize| -> I80F48 {
@@ -685,7 +839,7 @@ mod tests {
         scratch.complete = true;
 
         account
-            .update_premium_snapshots(&group, &scratch, 1_000)
+            .update_premium_snapshots(&group, &scratch, 1_000, false)
             .unwrap();
         assert_eq!(snapshot_rate(&account), I80F48::ZERO);
     }
@@ -702,7 +856,7 @@ mod tests {
         // complete deliberately left false (partial health pass)
 
         account
-            .update_premium_snapshots(&group, &scratch, 1_000)
+            .update_premium_snapshots(&group, &scratch, 1_000, false)
             .unwrap();
         assert_eq!(account.lending_account.balances[0].premium_rate_snapshot, 0);
         assert_eq!(account.lending_account.balances[0].last_update, 500);
@@ -723,7 +877,7 @@ mod tests {
         scratch.complete = true;
 
         account
-            .update_premium_snapshots(&group, &scratch, t0 + YEAR)
+            .update_premium_snapshots(&group, &scratch, t0 + YEAR, false)
             .unwrap();
 
         let balance = &account.lending_account.balances[0];
@@ -756,7 +910,7 @@ mod tests {
         scratch.complete = true;
 
         account
-            .update_premium_snapshots(&group, &scratch, 1_000)
+            .update_premium_snapshots(&group, &scratch, 1_000, false)
             .unwrap();
         let balance = &account.lending_account.balances[0];
         assert_eq!(I80F48::from(balance.premium_outstanding), I80F48::ZERO);
@@ -791,7 +945,7 @@ mod tests {
         scratch.complete = true;
 
         account
-            .update_premium_snapshots(&group, &scratch, 1_000)
+            .update_premium_snapshots(&group, &scratch, 1_000, false)
             .unwrap();
         assert_eq!(account.lending_account.balances[0].premium_rate_snapshot, 0);
     }
@@ -825,7 +979,7 @@ mod tests {
         scratch.complete = true;
 
         account
-            .update_premium_snapshots(&group, &scratch, 1_000)
+            .update_premium_snapshots(&group, &scratch, 1_000, false)
             .unwrap();
         assert_eq!(account.lending_account.balances[0].premium_rate_snapshot, 0);
         assert_approx(
@@ -850,7 +1004,7 @@ mod tests {
         scratch.complete = true;
 
         account
-            .update_premium_snapshots(&group, &scratch, 1_000)
+            .update_premium_snapshots(&group, &scratch, 1_000, false)
             .unwrap();
         let balance = &account.lending_account.balances[0];
         assert_approx(

--- a/programs/marginfi/src/state/premium.rs
+++ b/programs/marginfi/src/state/premium.rs
@@ -49,6 +49,12 @@
 //! * **Crank-order variance** — [`BalancePremiumImpl::claim_premium`] uses the liability
 //!   amount at claim time, so claiming before vs. after interest accrual differs by a
 //!   second-order term.
+//! * **Zero-health collateral excluded from the mix** — Isolated and `asset_weight_maint == 0`
+//!   banks contribute no premium weight (they back no health, so they must not dilute the
+//!   rate). Emode-only (base 0/0) collateral therefore contributes none either.
+//! * **Ratchet on unpriceable withdraw passes** — see the `ratchet_on_incomplete` flag on
+//!   [`MarginfiAccountPremiumImpl::update_premium_snapshots`]: genuine outages overcharge
+//!   forward-only until the next clean refresh.
 
 use anchor_lang::prelude::*;
 use fixed::types::I80F48;

--- a/programs/marginfi/tests/user_actions/premium.rs
+++ b/programs/marginfi/tests/user_actions/premium.rs
@@ -3082,6 +3082,144 @@ async fn premium_reactivation_before_touch_retains_materialized_receivable() -> 
 
     Ok(())
 }
+/// Finding: the liquidator's seized-collateral credit settles their accrued premium in the
+/// asset bank (vault-backed, like a repay) instead of writing it off when the credit closes
+/// their principal.
+#[tokio::test]
+async fn premium_liquidation_settles_liquidator_premium_instead_of_write_off() -> anyhow::Result<()>
+{
+    let mut test_f = TestFixture::new(Some(TestSettings {
+        banks: vec![
+            TestBankSetting {
+                mint: BankMint::Usdc,
+                config: Some(BankConfig {
+                    interest_rate_config: zero_interest_config(),
+                    ..*DEFAULT_USDC_TEST_BANK_CONFIG
+                }),
+            },
+            TestBankSetting {
+                mint: BankMint::Sol,
+                config: Some(BankConfig {
+                    asset_weight_init: I80F48!(1).into(),
+                    interest_rate_config: zero_interest_config(),
+                    ..*DEFAULT_SOL_TEST_BANK_CONFIG
+                }),
+            },
+        ],
+        protocol_fees: false,
+    }))
+    .await;
+    advance_clock(&test_f, 1_700_000_000).await;
+
+    let group_f = &test_f.marginfi_group;
+    let usdc_bank_f = test_f.get_bank(&BankMint::Usdc);
+    let sol_bank_f = test_f.get_bank(&BankMint::Sol);
+
+    // (stable -> sol) = 5%: a USDC-collateralized SOL borrow pays 5%.
+    group_f
+        .try_configure_group_premium(entry(TAG_STABLE, TAG_SOL, 5.0))
+        .await?;
+    group_f
+        .try_configure_bank_premium(usdc_bank_f, TAG_STABLE, true)
+        .await?;
+    group_f
+        .try_configure_bank_premium(sol_bank_f, TAG_SOL, true)
+        .await?;
+
+    // Liquidity for both borrow legs
+    let lender = test_f.create_marginfi_account().await;
+    let lender_usdc = test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(10_000)
+        .await;
+    lender
+        .try_bank_deposit(lender_usdc.key, usdc_bank_f, 10_000, None)
+        .await?;
+    let lender_sol = test_f
+        .sol_mint
+        .create_token_account_and_mint_to(10_000)
+        .await;
+    lender
+        .try_bank_deposit(lender_sol.key, sol_bank_f, 10_000, None)
+        .await?;
+
+    // Liquidator: USDC collateral, 100 SOL premium-active debt at 5%.
+    let liquidator = test_f.create_marginfi_account().await;
+    let liquidator_usdc = test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(2_000)
+        .await;
+    liquidator
+        .try_bank_deposit(liquidator_usdc.key, usdc_bank_f, 2_000, None)
+        .await?;
+    let liquidator_sol = test_f.sol_mint.create_empty_token_account().await;
+    liquidator
+        .try_bank_borrow(liquidator_sol.key, sol_bank_f, 100)
+        .await?;
+    let account = liquidator.load().await;
+    assert!((snapshot_percent(usdc_balance(&account, &sol_bank_f.key)) - 5.0).abs() < 0.001);
+
+    // Victim: SOL collateral, USDC debt.
+    let victim = test_f.create_marginfi_account().await;
+    let victim_sol = test_f
+        .sol_mint
+        .create_token_account_and_mint_to(1_000)
+        .await;
+    victim
+        .try_bank_deposit(victim_sol.key, sol_bank_f, 999, None)
+        .await?;
+    let victim_usdc = test_f.usdc_mint.create_empty_token_account().await;
+    victim
+        .try_bank_borrow(victim_usdc.key, usdc_bank_f, 3_000)
+        .await?;
+
+    // One year of premium on the liquidator's 100 SOL debt: P = 5 SOL.
+    advance_clock(&test_f, YEAR).await;
+
+    // Crush SOL collateral weights so the victim is liquidatable (the liquidator's SOL is a
+    // liability, so this leaves the liquidator untouched).
+    test_f
+        .get_bank_mut(&BankMint::Sol)
+        .update_config(
+            BankConfigOpt {
+                asset_weight_init: Some(I80F48!(0.01).into()),
+                asset_weight_maint: Some(I80F48!(0.02).into()),
+                ..Default::default()
+            },
+            None,
+        )
+        .await?;
+    let usdc_bank_f = test_f.get_bank(&BankMint::Usdc);
+    let sol_bank_f = test_f.get_bank(&BankMint::Sol);
+
+    let collected_before: I80F48 = sol_bank_f.load().await.collected_premium_outstanding.into();
+    assert_eq!(collected_before, I80F48::ZERO);
+
+    // Seize 120 SOL: covers the 100 SOL principal + 5 SOL premium, remainder deposits.
+    liquidator
+        .try_liquidate(&victim, sol_bank_f, 120, usdc_bank_f)
+        .await?;
+
+    // The premium was settled into the bank's swept-premium counter, NOT written off.
+    let collected_after: I80F48 = sol_bank_f.load().await.collected_premium_outstanding.into();
+    assert_eq_noise!(
+        collected_after,
+        I80F48::from(native!(5, "SOL")),
+        I80F48!(10_000) // rate-encoding granularity on 5e9 native units
+    );
+
+    // Liquidator's SOL leg: principal closed, premium cleared by SETTLEMENT, remainder
+    // (120 - 100 - 5 = 15 SOL) landed as a deposit.
+    let account = liquidator.load().await;
+    let sol_balance = usdc_balance(&account, &sol_bank_f.key);
+    assert_eq!(I80F48::from(sol_balance.premium_outstanding), I80F48::ZERO);
+    assert_eq_noise!(
+        I80F48::from(sol_balance.asset_shares), // share value 1 (zero interest)
+        I80F48::from(native!(15, "SOL")),
+        I80F48!(10_000)
+    );
+    Ok(())
+}
 
 /// Finding: a withdraw that supplies a wrong oracle for a premium-tagged collateral leg used
 /// to freeze the (diluted) snapshot. Now it ratchets to the unpriceable leg's full pair rate.

--- a/programs/marginfi/tests/user_actions/premium.rs
+++ b/programs/marginfi/tests/user_actions/premium.rs
@@ -1751,12 +1751,13 @@ async fn premium_reopened_liability_pays_nothing_for_debt_free_gap() -> anyhow::
     Ok(())
 }
 
-/// Withdrawing during an oracle outage is NOT blocked: the premium refresh no-ops on the
-/// incomplete pass and the old rate persists (re-priced later by pulse). Blocking would let a
-/// dead-oracle collateral freeze a healthy withdraw; keeping a stale rate is safe since premium
-/// is still charged and projected.
+/// Withdrawing during an oracle outage is NOT blocked — but since the pass is incomplete, the
+/// snapshot RATCHETS: the unpriceable leg is priced at its full pair rate and the rate can only
+/// move up (never diluted down). This closes the "withdraw the cheap collateral while the
+/// tagged leg's oracle is out" freeze; a later clean refresh re-prices freely (down included),
+/// so honest outages overcharge forward-only for roughly one pulse interval.
 #[tokio::test]
-async fn premium_withdraw_keeps_old_rate_when_collateral_oracle_stale() -> anyhow::Result<()> {
+async fn premium_withdraw_during_oracle_outage_ratchets_not_blocked() -> anyhow::Result<()> {
     let test_f = TestFixture::new(Some(TestSettings {
         banks: vec![
             TestBankSetting {
@@ -1834,20 +1835,20 @@ async fn premium_withdraw_keeps_old_rate_when_collateral_oracle_stale() -> anyho
     let rate_before = snapshot_percent(usdc_balance(&account, &usdc_bank_f.key));
     assert!((rate_before - 0.5).abs() < 0.001);
 
-    // Tagged SOL oracle goes stale; the withdraw soft-skips it and still passes on the untagged
-    // SolEq. The premium refresh can't run (incomplete pass), but the withdraw is NOT blocked.
+    // Tagged SOL oracle goes stale; the withdraw soft-skips it for health and still passes on
+    // the untagged SolEq. The withdraw is NOT blocked — the snapshot ratchets to the
+    // unpriceable SOL leg's full pair rate instead of silently keeping the diluted 0.5%.
     advance_clock_with_feeds(&test_f, 3_600, &[PYTH_USDC_FEED, PYTH_SOL_EQUIVALENT_FEED]).await;
 
     borrower
         .try_bank_withdraw(borrower_sol_eq.key, sol_eq_bank_f, 10, None)
         .await?;
 
-    // The snapshot is untouched (old rate kept, not zeroed) — premium keeps being charged.
     let account = borrower.load().await;
     let rate_after = snapshot_percent(usdc_balance(&account, &usdc_bank_f.key));
     assert!(
-        (rate_after - rate_before).abs() < 1e-9,
-        "rate should be unchanged: {} -> {}",
+        (rate_after - 1.0).abs() < 0.001,
+        "rate should ratchet {} -> 1.0%, got {}",
         rate_before,
         rate_after
     );
@@ -3079,5 +3080,116 @@ async fn premium_reactivation_before_touch_retains_materialized_receivable() -> 
         I80F48!(100)
     );
 
+    Ok(())
+}
+
+/// Finding: a withdraw that supplies a wrong oracle for a premium-tagged collateral leg used
+/// to freeze the (diluted) snapshot. Now it ratchets to the unpriceable leg's full pair rate.
+#[tokio::test]
+async fn premium_withdraw_with_bad_oracle_ratchets_instead_of_freezing() -> anyhow::Result<()> {
+    use solana_sdk::transaction::Transaction;
+
+    let test_f = TestFixture::new(Some(TestSettings {
+        banks: vec![
+            TestBankSetting {
+                mint: BankMint::Usdc,
+                config: Some(BankConfig {
+                    interest_rate_config: zero_interest_config(),
+                    ..*DEFAULT_USDC_TEST_BANK_CONFIG
+                }),
+            },
+            TestBankSetting {
+                mint: BankMint::Sol,
+                config: Some(BankConfig {
+                    asset_weight_init: I80F48!(1).into(),
+                    ..*DEFAULT_SOL_TEST_BANK_CONFIG
+                }),
+            },
+            TestBankSetting {
+                mint: BankMint::SolEquivalent,
+                config: Some(BankConfig {
+                    asset_weight_init: I80F48!(1).into(),
+                    ..*DEFAULT_SOL_EQUIVALENT_TEST_BANK_CONFIG
+                }),
+            },
+        ],
+        protocol_fees: false,
+    }))
+    .await;
+    advance_clock(&test_f, 1_700_000_000).await;
+    let group_f = &test_f.marginfi_group;
+    group_f
+        .try_configure_group_premium(entry(TAG_SOL, TAG_STABLE, 1.0))
+        .await?;
+    let usdc_bank_f = test_f.get_bank(&BankMint::Usdc);
+    let sol_eq_bank_f = test_f.get_bank(&BankMint::SolEquivalent);
+    group_f
+        .try_configure_bank_premium(usdc_bank_f, TAG_STABLE, true)
+        .await?;
+    group_f
+        .try_configure_bank_premium(test_f.get_bank(&BankMint::Sol), TAG_SOL, true)
+        .await?;
+
+    // Tagged SOL + equal untagged SolEq -> diluted 0.5% snapshot.
+    let (_lender, borrower, _) = setup_borrower(&test_f, 1_000.0).await;
+    let sol_eq_account = test_f
+        .sol_equivalent_mint
+        .create_token_account_and_mint_to(1_000)
+        .await;
+    borrower
+        .try_bank_deposit(sol_eq_account.key, sol_eq_bank_f, 999, None)
+        .await?;
+    borrower.try_lending_account_pulse_health().await?;
+    let account = borrower.load().await;
+    assert!((snapshot_percent(usdc_balance(&account, &usdc_bank_f.key)) - 0.5).abs() < 0.001);
+
+    // Withdraw 1 SolEq while passing a WRONG oracle account for the tagged SOL leg. Health
+    // soft-zeroes SOL and still passes on SolEq; pre-fix the premium refresh silently
+    // no-opped and the 0.5% survived.
+    let payer = test_f.payer();
+    let withdraw_dest = test_f
+        .sol_equivalent_mint
+        .create_empty_token_account()
+        .await;
+    let mut ix = borrower
+        .make_withdraw_ix_with_authority(withdraw_dest.key, sol_eq_bank_f, 1.0, None, payer)
+        .await;
+    let mut tampered = 0;
+    for meta in ix.accounts.iter_mut() {
+        if meta.pubkey == PYTH_SOL_FEED {
+            meta.pubkey = Pubkey::new_unique();
+            tampered += 1;
+        }
+    }
+    assert_eq!(tampered, 1, "expected exactly one SOL oracle meta");
+    {
+        let ctx = test_f.context.borrow_mut();
+        let tx = Transaction::new_signed_with_payer(
+            &[ix],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await?,
+        );
+        ctx.banks_client.process_transaction(tx).await?;
+    }
+
+    // Ratcheted to the unpriceable SOL leg's full pair rate.
+    let account = borrower.load().await;
+    let rate = snapshot_percent(usdc_balance(&account, &usdc_bank_f.key));
+    assert!(
+        (rate - 1.0).abs() < 0.001,
+        "bad-oracle withdraw must ratchet to 1.0%, got {}",
+        rate
+    );
+
+    // A clean permissionless pulse recomputes freely back down to the true weighted rate.
+    borrower.try_lending_account_pulse_health().await?;
+    let account = borrower.load().await;
+    let rate = snapshot_percent(usdc_balance(&account, &usdc_bank_f.key));
+    assert!(
+        (rate - 0.5).abs() < 0.001,
+        "clean pulse must restore the true rate, got {}",
+        rate
+    );
     Ok(())
 }

--- a/programs/marginfi/tests/user_actions/premium.rs
+++ b/programs/marginfi/tests/user_actions/premium.rs
@@ -3082,6 +3082,76 @@ async fn premium_reactivation_before_touch_retains_materialized_receivable() -> 
 
     Ok(())
 }
+
+/// Finding: a Collateral-tier bank with 0/0 asset weights backs no health, so it must not
+/// tilt the premium mix either (pre-fix its raw USD diluted the rate at zero health cost).
+#[tokio::test]
+async fn premium_zero_weight_collateral_does_not_dilute_the_mix() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings {
+        banks: vec![
+            TestBankSetting {
+                mint: BankMint::Usdc,
+                config: Some(BankConfig {
+                    interest_rate_config: zero_interest_config(),
+                    ..*DEFAULT_USDC_TEST_BANK_CONFIG
+                }),
+            },
+            TestBankSetting {
+                mint: BankMint::Sol,
+                config: Some(BankConfig {
+                    asset_weight_init: I80F48!(1).into(),
+                    ..*DEFAULT_SOL_TEST_BANK_CONFIG
+                }),
+            },
+            // Collateral tier, but weightless: legal per config validation.
+            TestBankSetting {
+                mint: BankMint::SolEquivalent,
+                config: Some(BankConfig {
+                    asset_weight_init: I80F48!(0).into(),
+                    asset_weight_maint: I80F48!(0).into(),
+                    ..*DEFAULT_SOL_EQUIVALENT_TEST_BANK_CONFIG
+                }),
+            },
+        ],
+        protocol_fees: false,
+    }))
+    .await;
+    advance_clock(&test_f, 1_700_000_000).await;
+    let group_f = &test_f.marginfi_group;
+    group_f
+        .try_configure_group_premium(entry(TAG_SOL, TAG_STABLE, 1.0))
+        .await?;
+    let usdc_bank_f = test_f.get_bank(&BankMint::Usdc);
+    let sol_eq_bank_f = test_f.get_bank(&BankMint::SolEquivalent);
+    group_f
+        .try_configure_bank_premium(usdc_bank_f, TAG_STABLE, true)
+        .await?;
+    group_f
+        .try_configure_bank_premium(test_f.get_bank(&BankMint::Sol), TAG_SOL, true)
+        .await?;
+
+    let (_lender, borrower, _) = setup_borrower(&test_f, 1_000.0).await;
+
+    // Equal USD of 0/0-weight collateral: pre-fix this halved the rate to 0.5%.
+    let sol_eq_account = test_f
+        .sol_equivalent_mint
+        .create_token_account_and_mint_to(1_000)
+        .await;
+    borrower
+        .try_bank_deposit(sol_eq_account.key, sol_eq_bank_f, 999, None)
+        .await?;
+    borrower.try_lending_account_pulse_health().await?;
+
+    let account = borrower.load().await;
+    let rate = snapshot_percent(usdc_balance(&account, &usdc_bank_f.key));
+    assert!(
+        (rate - 1.0).abs() < 0.0001,
+        "0/0-weight collateral must not dilute: {} != 1.0%",
+        rate
+    );
+    Ok(())
+}
+
 /// Finding: the liquidator's seized-collateral credit settles their accrued premium in the
 /// asset bank (vault-backed, like a repay) instead of writing it off when the credit closes
 /// their principal.


### PR DESCRIPTION
3 fixes: 

1. Incomplete oracle pricing will undercharge the protocol after a borrower withdraws rate-diluting collateral
2. Liquidators can avoid the premium fee through a liquidation write-off
3. Zero-weight collateral does not help health but still cuts the premium rate