### PR TITLE
Prohibit durable nonce admin

### DIFF
--- a/programs/marginfi/fuzz/Cargo.lock
+++ b/programs/marginfi/fuzz/Cargo.lock
@@ -430,7 +430,7 @@ dependencies = [
  "solana-define-syscall 3.0.0",
  "solana-feature-gate-interface",
  "solana-instruction",
- "solana-instructions-sysvar",
+ "solana-instructions-sysvar 3.0.1",
  "solana-invoke",
  "solana-loader-v3-interface",
  "solana-msg",
@@ -3477,7 +3477,7 @@ dependencies = [
  "marginfi-type-crate",
  "pyth-solana-receiver-sdk 1.2.1 (git+https://github.com/0dotxyz/pyth-crosschain?rev=f170d205e47a6ea34ad30c424d9ec8cc61a1f1fc)",
  "solana-borsh",
- "solana-instructions-sysvar",
+ "solana-instructions-sysvar 3.0.1",
  "solana-msg",
  "solana-program",
  "solana-security-txt",
@@ -3516,6 +3516,7 @@ dependencies = [
  "quinn-proto 0.10.6",
  "rand 0.8.5",
  "safe-transmute",
+ "solana-instructions-sysvar 4.0.0",
  "solana-program",
  "solana-program-test",
  "solana-sdk",
@@ -6459,6 +6460,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-instructions-sysvar"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e38363a181313d607f7a118df2b401bb27b477a0104b09283cbf504f5f0f00cc"
+dependencies = [
+ "bitflags",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-program-error",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-serialize-utils",
+ "solana-sysvar-id",
+]
+
+[[package]]
 name = "solana-invoke"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6831,7 +6849,7 @@ dependencies = [
  "solana-hash 3.1.0",
  "solana-instruction",
  "solana-instruction-error",
- "solana-instructions-sysvar",
+ "solana-instructions-sysvar 3.0.1",
  "solana-keccak-hasher",
  "solana-last-restart-slot",
  "solana-msg",
@@ -7815,7 +7833,7 @@ dependencies = [
  "solana-fee-structure",
  "solana-hash 3.1.0",
  "solana-instruction",
- "solana-instructions-sysvar",
+ "solana-instructions-sysvar 3.0.1",
  "solana-loader-v3-interface",
  "solana-loader-v4-interface",
  "solana-loader-v4-program",
@@ -8137,7 +8155,7 @@ dependencies = [
  "serde",
  "solana-account",
  "solana-instruction",
- "solana-instructions-sysvar",
+ "solana-instructions-sysvar 3.0.1",
  "solana-pubkey 3.0.0",
  "solana-rent 3.1.0",
  "solana-sbpf",
@@ -8847,7 +8865,7 @@ dependencies = [
  "solana-account-info",
  "solana-curve25519 3.1.12",
  "solana-instruction",
- "solana-instructions-sysvar",
+ "solana-instructions-sysvar 3.0.1",
  "solana-msg",
  "solana-program-error",
  "solana-pubkey 3.0.0",
@@ -8868,7 +8886,7 @@ dependencies = [
  "solana-address 2.6.0",
  "solana-curve25519 4.0.1",
  "solana-instruction",
- "solana-instructions-sysvar",
+ "solana-instructions-sysvar 3.0.1",
  "solana-msg",
  "solana-program-error",
  "solana-sdk-ids",

--- a/programs/marginfi/fuzz/Cargo.lock
+++ b/programs/marginfi/fuzz/Cargo.lock
@@ -2107,6 +2107,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "exponent-mocks"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "bytemuck",
+ "marginfi-type-crate",
+ "static_assertions",
+]
+
+[[package]]
 name = "fast-math"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,6 +3167,7 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "bytemuck",
+ "fixed",
 ]
 
 [[package]]
@@ -3468,6 +3479,7 @@ dependencies = [
  "cfg-if",
  "drift-mocks",
  "enum_dispatch",
+ "exponent-mocks",
  "fixed",
  "fixed-macro",
  "id-crate",
@@ -3475,7 +3487,9 @@ dependencies = [
  "kamino-mocks",
  "lazy_static",
  "marginfi-type-crate",
+ "marinade-mocks",
  "pyth-solana-receiver-sdk 1.2.1 (git+https://github.com/0dotxyz/pyth-crosschain?rev=f170d205e47a6ea34ad30c424d9ec8cc61a1f1fc)",
+ "scope-mocks",
  "solana-borsh",
  "solana-instructions-sysvar 3.0.1",
  "solana-msg",
@@ -3527,7 +3541,7 @@ dependencies = [
 
 [[package]]
 name = "marginfi-type-crate"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anchor-lang",
  "bs58",
@@ -3537,6 +3551,16 @@ dependencies = [
  "id-crate",
  "solana-instruction",
  "spl-associated-token-account",
+ "static_assertions",
+]
+
+[[package]]
+name = "marinade-mocks"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "bytemuck",
+ "marginfi-type-crate",
  "static_assertions",
 ]
 
@@ -5088,6 +5112,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "scope-mocks"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "bytemuck",
+ "marginfi-type-crate",
+ "static_assertions",
 ]
 
 [[package]]

--- a/programs/marginfi/fuzz/Cargo.toml
+++ b/programs/marginfi/fuzz/Cargo.toml
@@ -20,6 +20,7 @@ solana-program = "=3.0.0"
 solana-program-test = { version = "=3.1.12", features = ["agave-unstable-api"] }
 spl-token = "9.0.0"
 spl-token-2022 = "11.0.0"
+solana-instructions-sysvar = "4.0.0"
 
 anchor-lang = { version = "1.0.2" }
 anchor-spl = { version = "1.0.2", default-features = false, features = ["associated_token", "token", "token_2022"] }

--- a/programs/marginfi/fuzz/src/account_state.rs
+++ b/programs/marginfi/fuzz/src/account_state.rs
@@ -24,6 +24,7 @@ use solana_program::{
 };
 use solana_sdk::{signature::Keypair, signer::Signer};
 use std::mem::size_of;
+use solana_instructions_sysvar;
 
 pub struct AccountsState {
     pub bump: Bump,
@@ -408,6 +409,21 @@ impl AccountsState {
         rent.to_account_info(&mut account_info).unwrap();
 
         account_info
+    }
+
+    pub fn new_instruction_sysvar_account(&self) -> AccountInfo<'_> {
+        let id_key = solana_instructions_sysvar::id();
+        let data = self.bump.alloc_slice_fill_copy(0, 0u8);
+
+        AccountInfo::new(
+            self.bump.alloc(id_key),
+            false,
+            false,
+            self.bump.alloc(0),
+            data,
+            &sysvar::ID,
+            false,
+        )
     }
 
     pub fn new_vault_account<'a>(

--- a/programs/marginfi/fuzz/src/lib.rs
+++ b/programs/marginfi/fuzz/src/lib.rs
@@ -57,6 +57,7 @@ pub struct MarginfiFuzzContext<'info> {
     pub marginfi_accounts: Vec<UserAccount<'info>>,
     pub owner: AccountInfo<'info>,
     pub system_program: AccountInfo<'info>,
+    pub instruction_sysvar: AccountInfo<'info>,
     pub last_sysvar_current_timestamp: RwLock<u64>,
     pub metrics: Arc<RwLock<Metrics>>,
     pub state: &'info AccountsState,
@@ -91,6 +92,7 @@ impl<'state> MarginfiFuzzContext<'state> {
             banks: vec![],
             owner: admin,
             system_program,
+            instruction_sysvar: state.new_instruction_sysvar_account(),
             marginfi_accounts: vec![],
             last_sysvar_current_timestamp: RwLock::new(
                 SystemTime::now()
@@ -263,6 +265,7 @@ impl<'state> MarginfiFuzzContext<'state> {
                         fee_vault: Box::new(InterfaceAccount::try_from(airls(&fee_vault)).unwrap()),
                         token_program: Interface::try_from(airls(&token_program)).unwrap(),
                         system_program: Program::try_from(airls(&self.system_program)).unwrap(),
+                        instruction_sysvar: uails(&self.instruction_sysvar),
                     },
                     &[],
                     add_bank_bumps,
@@ -319,6 +322,7 @@ impl<'state> MarginfiFuzzContext<'state> {
                         admin: Signer::try_from(airls(&self.owner)).unwrap(),
                         bank: AccountLoader::try_from_unchecked(&marginfi::ID, airls(&bank))
                             .unwrap(),
+                        instruction_sysvar: uails(&self.instruction_sysvar),
                     },
                     &[ails(oracle.clone())],
                     configure_bumps,
@@ -961,6 +965,7 @@ impl<'state> MarginfiFuzzContext<'state> {
                 ))?),
                 insurance_vault_authority: uails(&bank.insurance_vault_authority),
                 token_program: Interface::try_from(airls(&bank.token_program))?,
+                instruction_sysvar: uails(&self.instruction_sysvar),
             },
             aisls(&remaining_accounts),
             Default::default(),
@@ -1041,16 +1046,17 @@ fn initialize_marginfi_group<'a>(
     let program_id = marginfi::ID;
     let marginfi_group =
         state.new_owned_account(size_of::<MarginfiGroup>(), program_id, Rent::free());
+    let instruction_sysvar = state.new_instruction_sysvar_account();
 
     marginfi::instructions::marginfi_group::initialize_group(Context::new(
         &marginfi::ID,
         &mut marginfi::instructions::MarginfiGroupInitialize {
-            // Unchecked because we are initializing the account.
             marginfi_group: AccountLoader::try_from_unchecked(&program_id, airls(&marginfi_group))
                 .unwrap(),
             admin: Signer::try_from(airls(&admin)).unwrap(),
             fee_state: AccountLoader::try_from_unchecked(&program_id, airls(&fee_state)).unwrap(),
             system_program: Program::try_from(airls(&system_program)).unwrap(),
+            instruction_sysvar: uails(&instruction_sysvar),
         },
         &[],
         Default::default(),
@@ -1059,6 +1065,7 @@ fn initialize_marginfi_group<'a>(
 
     set_discriminator::<MarginfiGroup>(marginfi_group.clone());
 
+    let instruction_sysvar = state.new_instruction_sysvar_account();
     marginfi::instructions::marginfi_group::configure(
         Context::new(
             &marginfi::ID,
@@ -1069,6 +1076,7 @@ fn initialize_marginfi_group<'a>(
                 )
                 .unwrap(),
                 admin: Signer::try_from(airls(&admin)).unwrap(),
+                instruction_sysvar: uails(&instruction_sysvar),
             },
             &[],
             Default::default(),

--- a/programs/marginfi/src/errors.rs
+++ b/programs/marginfi/src/errors.rs
@@ -456,6 +456,11 @@ pub enum MarginfiError {
     CircuitBreakerPriceJump, // 6604
     // **************END CIRCUIT BREAKER ERRORS
 
+    // ************** BEGIN ADMIN GUARD ERRORS (starting at 6605)
+    #[msg("Durable nonce cannot be used for this instruction")]
+    DurableNonceNotAllowed = 605, // 6605
+    // ************** END ADMIN GUARD ERRORS
+
     // ************** BEGIN PREMIUM ERRORS (starting at 6610)
     #[msg("Premium entry has a zero collateral or liability tag")]
     PremiumEntryInvalid = 610, // 6610
@@ -770,6 +775,7 @@ impl From<u32> for MarginfiError {
             6602 => MarginfiError::CircuitBreakerInvalidConfig,
             6603 => MarginfiError::CircuitBreakerRequiresWarmCache,
             6604 => MarginfiError::CircuitBreakerPriceJump,
+            6605 => MarginfiError::DurableNonceNotAllowed,
             6700 => MarginfiError::RebalanceVenueUnsupported,
             6701 => MarginfiError::RebalanceCooldown,
             6702 => MarginfiError::RebalanceIncompleteMove,

--- a/programs/marginfi/src/instructions/drift/add_pool.rs
+++ b/programs/marginfi/src/instructions/drift/add_pool.rs
@@ -1,3 +1,4 @@
+use crate::ix_utils;
 // Adds a Drift type bank to a group with sane defaults. Used to integrate with Drift
 // allowing users to interact with Drift spot markets through marginfi
 use crate::{
@@ -28,6 +29,8 @@ pub fn lending_pool_add_bank_drift(
     bank_config: DriftConfigCompact,
     bank_seed: u64,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     // Note: Drift banks don't need to debit the flat SOL fee because these will always be
     // first-party pools owned by mrgn and never permissionless pools
     let LendingPoolAddBankDrift {
@@ -249,4 +252,7 @@ pub struct LendingPoolAddBankDrift<'info> {
 
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/drift/add_pool.rs
+++ b/programs/marginfi/src/instructions/drift/add_pool.rs
@@ -253,6 +253,7 @@ pub struct LendingPoolAddBankDrift<'info> {
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/juplend/add_pool.rs
+++ b/programs/marginfi/src/instructions/juplend/add_pool.rs
@@ -1,3 +1,4 @@
+use crate::ix_utils;
 // Adds a JupLend type bank to a group with sane defaults. Used to integrate with JupLend
 // allowing users to interact with JupLend lending pools through marginfi.
 use crate::{
@@ -31,6 +32,7 @@ pub fn lending_pool_add_bank_juplend(
     bank_config: JuplendConfigCompact,
     bank_seed: u64,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
     // Note: JupLend banks don't need to debit the flat SOL fee because these will always be
     // first-party pools owned by mrgn and never permissionless pools
     let LendingPoolAddBankJuplend {
@@ -249,4 +251,7 @@ pub struct LendingPoolAddBankJuplend<'info> {
     /// JupLend creates fToken mints using the same token program as the underlying.
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/juplend/add_pool.rs
+++ b/programs/marginfi/src/instructions/juplend/add_pool.rs
@@ -252,6 +252,7 @@ pub struct LendingPoolAddBankJuplend<'info> {
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/kamino/add_pool.rs
+++ b/programs/marginfi/src/instructions/kamino/add_pool.rs
@@ -241,6 +241,7 @@ pub struct LendingPoolAddBankKamino<'info> {
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/kamino/add_pool.rs
+++ b/programs/marginfi/src/instructions/kamino/add_pool.rs
@@ -1,3 +1,4 @@
+use crate::ix_utils;
 // Adds a Kamino type bank to a group with sane defaults. Used to integrate with Kamino
 // allowing users to interact with Kamino pools through marginfi
 use crate::{
@@ -28,6 +29,7 @@ pub fn lending_pool_add_bank_kamino(
     bank_config: KaminoConfigCompact,
     bank_seed: u64,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
     // Note: Kamino banks don't need to debit the flat SOL fee because these will always be
     // first-party pools owned by mrgn and never permissionless pools
     let LendingPoolAddBankKamino {
@@ -238,4 +240,7 @@ pub struct LendingPoolAddBankKamino<'info> {
 
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_account/freeze.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/freeze.rs
@@ -58,6 +58,7 @@ pub struct SetAccountFreeze<'info> {
     )]
     pub admin: Signer<'info>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_account/freeze.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/freeze.rs
@@ -5,6 +5,7 @@
 /// - The group admin retains access to operate the account while frozen (for remediation/seizure).
 /// - Setting `frozen = false` clears the flag and returns control to the authority under normal auth rules.
 pub fn set_account_freeze(ctx: Context<SetAccountFreeze>, frozen: bool) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
     let group = ctx.accounts.group.load()?;
     check_eq!(
         group.admin,
@@ -35,6 +36,7 @@ pub fn set_account_freeze(ctx: Context<SetAccountFreeze>, frozen: bool) -> Margi
 use crate::{
     check_eq,
     events::{AccountEventHeader, MarginfiAccountFreezeEvent},
+    ix_utils,
     prelude::*,
     state::marginfi_account::MarginfiAccountImpl,
 };
@@ -55,4 +57,7 @@ pub struct SetAccountFreeze<'info> {
         constraint = group.load()?.admin == admin.key() @ MarginfiError::Unauthorized
     )]
     pub admin: Signer<'info>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate_end.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate_end.rs
@@ -1,3 +1,4 @@
+use crate::ix_utils;
 use crate::{
     check,
     constants::{LIQUIDATION_BONUS_FEE_MINIMUM, LIQUIDATION_CLOSEOUT_DOLLAR_THRESHOLD},
@@ -88,6 +89,7 @@ pub fn end_liquidation<'info>(ctx: Context<'info, EndLiquidation<'info>>) -> Mar
 /// * Fails if account is less healthy than it was at start
 ///   Note: no fees taken.
 pub fn end_deleverage<'info>(ctx: Context<'info, EndDeleverage<'info>>) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
     let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
     let mut liq_record = ctx.accounts.liquidation_record.load_mut()?;
     let group = ctx.accounts.group.load()?;
@@ -308,6 +310,9 @@ pub struct EndDeleverage<'info> {
     pub group: AccountLoader<'info, MarginfiGroup>,
 
     pub risk_admin: Signer<'info>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 impl Hashable for EndDeleverage<'_> {

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate_end.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate_end.rs
@@ -311,7 +311,8 @@ pub struct EndDeleverage<'info> {
 
     pub risk_admin: Signer<'info>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate_start.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate_start.rs
@@ -1,3 +1,4 @@
+use crate::ix_utils;
 use crate::{
     check,
     constants::{ASSOCIATED_TOKEN_KEY, COMPUTE_PROGRAM_KEY, JUP_KEY, TITAN_KEY},
@@ -73,6 +74,7 @@ pub fn start_liquidation<'info>(ctx: Context<'info, StartLiquidation<'info>>) ->
 /// * Fails if any mrgn instruction other than start, end, withdraw, or repay (or the equivalent
 ///   from a third party integration) are used within this tx.
 pub fn start_deleverage<'info>(ctx: Context<'info, StartDeleverage<'info>>) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
     let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
     let mut liq_record = ctx.accounts.liquidation_record.load_mut()?;
     liq_record.liquidation_receiver = ctx.accounts.risk_admin.key();

--- a/programs/marginfi/src/instructions/marginfi_account/purge_delev_balance.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/purge_delev_balance.rs
@@ -76,6 +76,7 @@ pub struct LendingAccountPurgeDelevBalance<'info> {
     )]
     pub bank: AccountLoader<'info, Bank>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_account/purge_delev_balance.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/purge_delev_balance.rs
@@ -6,6 +6,7 @@ use marginfi_type_crate::{
 };
 
 use crate::{
+    ix_utils,
     prelude::*,
     state::{
         bank::BankImpl,
@@ -16,6 +17,7 @@ use crate::{
 pub fn lending_account_purge_delev_balance(
     ctx: Context<LendingAccountPurgeDelevBalance>,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
     let bank_pk = &ctx.accounts.bank.key();
     let mut bank = ctx.accounts.bank.load_mut()?;
     let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
@@ -73,4 +75,7 @@ pub struct LendingAccountPurgeDelevBalance<'info> {
             @ MarginfiError::ForbiddenIx
     )]
     pub bank: AccountLoader<'info, Bank>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/add_pool.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool.rs
@@ -215,7 +215,8 @@ pub struct LendingPoolAddBank<'info> {
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 

--- a/programs/marginfi/src/instructions/marginfi_group/add_pool.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool.rs
@@ -1,6 +1,6 @@
 use crate::{
     events::{GroupEventHeader, LendingPoolBankCreateEvent},
-    log_pool_info,
+    ix_utils, log_pool_info,
     state::{bank::BankImpl, bank_config::BankConfigImpl, marginfi_group::MarginfiGroupImpl},
     MarginfiError, MarginfiResult,
 };
@@ -22,6 +22,8 @@ pub fn lending_pool_add_bank(
     ctx: Context<LendingPoolAddBank>,
     bank_config: BankConfigCompact,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     // Transfer the flat sol init fee to the global fee wallet
     let fee_state = ctx.accounts.fee_state.load()?;
     let bank_init_flat_sol_fee = fee_state.bank_init_flat_sol_fee;
@@ -212,6 +214,9 @@ pub struct LendingPoolAddBank<'info> {
 
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 impl<'info> LendingPoolAddBank<'info> {

--- a/programs/marginfi/src/instructions/marginfi_group/add_pool_with_seed.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool_with_seed.rs
@@ -1,6 +1,6 @@
 use crate::{
     events::{GroupEventHeader, LendingPoolBankCreateEvent},
-    log_pool_info,
+    ix_utils, log_pool_info,
     state::{bank::BankImpl, bank_config::BankConfigImpl, marginfi_group::MarginfiGroupImpl},
     MarginfiError, MarginfiResult,
 };
@@ -24,6 +24,8 @@ pub fn lending_pool_add_bank_with_seed(
     bank_config: BankConfigCompact,
     bank_seed: u64,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     // Transfer the flat sol init fee to the global fee wallet
     let fee_state = ctx.accounts.fee_state.load()?;
     let bank_init_flat_sol_fee = fee_state.bank_init_flat_sol_fee;
@@ -215,6 +217,9 @@ pub struct LendingPoolAddBankWithSeed<'info> {
 
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 impl<'info> LendingPoolAddBankWithSeed<'info> {

--- a/programs/marginfi/src/instructions/marginfi_group/add_pool_with_seed.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool_with_seed.rs
@@ -218,7 +218,8 @@ pub struct LendingPoolAddBankWithSeed<'info> {
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 

--- a/programs/marginfi/src/instructions/marginfi_group/clear_circuit_breaker.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/clear_circuit_breaker.rs
@@ -64,6 +64,7 @@ pub struct LendingPoolClearCircuitBreaker<'info> {
     #[account(mut, has_one = group @ MarginfiError::InvalidGroup)]
     pub bank: AccountLoader<'info, Bank>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/clear_circuit_breaker.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/clear_circuit_breaker.rs
@@ -1,5 +1,6 @@
 use crate::{
     events::{CircuitBreakerClearedEvent, CB_CLEAR_REASON_ADMIN},
+    ix_utils,
     state::bank::BankImpl,
     MarginfiError, MarginfiResult,
 };
@@ -16,6 +17,8 @@ pub fn lending_pool_clear_circuit_breaker(
     ctx: Context<LendingPoolClearCircuitBreaker>,
     reseed_reference: bool,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     {
         let group = ctx.accounts.group.load()?;
         let signer = ctx.accounts.authority.key();
@@ -60,4 +63,7 @@ pub struct LendingPoolClearCircuitBreaker<'info> {
 
     #[account(mut, has_one = group @ MarginfiError::InvalidGroup)]
     pub bank: AccountLoader<'info, Bank>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/clone_bank.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/clone_bank.rs
@@ -2,7 +2,7 @@ use crate::{
     check,
     constants::{LOCALNET_ID, MAINNET_PROGRAM_ID, STAGING_ID},
     events::{GroupEventHeader, LendingPoolBankCreateEvent},
-    log_pool_info,
+    ix_utils, log_pool_info,
     state::{bank::BankImpl, marginfi_group::MarginfiGroupImpl},
     MarginfiError, MarginfiResult,
 };
@@ -21,6 +21,8 @@ pub fn lending_pool_clone_bank(
     ctx: Context<LendingPoolCloneBank>,
     bank_seed: u64,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     if crate::ID != STAGING_ID && crate::ID != LOCALNET_ID {
         panic!("Staging or localnet only!");
     }
@@ -253,4 +255,7 @@ pub struct LendingPoolCloneBank<'info> {
 
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/clone_bank.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/clone_bank.rs
@@ -256,6 +256,7 @@ pub struct LendingPoolCloneBank<'info> {
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/close_bank.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/close_bank.rs
@@ -77,6 +77,7 @@ pub struct LendingPoolCloseBank<'info> {
     #[account(mut)]
     pub admin: Signer<'info>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/close_bank.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/close_bank.rs
@@ -1,4 +1,5 @@
 use crate::check;
+use crate::ix_utils;
 use crate::state::bank::BankImpl;
 use crate::utils::NumTraitsWithTolerance;
 use crate::{MarginfiError, MarginfiResult};
@@ -17,6 +18,8 @@ pub fn lending_pool_close_bank(
     ctx: Context<LendingPoolCloseBank>,
     force_close: Option<bool>,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut group = ctx.accounts.group.load_mut()?;
     // Note: Groups created prior to 0.1.2 have a non-authoritative count here, so subtraction
     // without saturation could reduce the count below zero.
@@ -73,4 +76,7 @@ pub struct LendingPoolCloseBank<'info> {
 
     #[account(mut)]
     pub admin: Signer<'info>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/collect_bank_fees.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/collect_bank_fees.rs
@@ -329,7 +329,8 @@ pub struct LendingPoolWithdrawFees<'info> {
 
     pub token_program: Interface<'info, TokenInterface>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
@@ -413,7 +414,8 @@ pub struct LendingPoolWithdrawInsurance<'info> {
 
     pub token_program: Interface<'info, TokenInterface>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
@@ -457,7 +459,8 @@ pub struct LendingPoolUpdateFeesDestinationAccount<'info> {
     )]
     pub destination_account: InterfaceAccount<'info, TokenAccount>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 

--- a/programs/marginfi/src/instructions/marginfi_group/collect_bank_fees.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/collect_bank_fees.rs
@@ -1,4 +1,5 @@
 use crate::events::{GroupEventHeader, LendingPoolBankCollectFeesEvent};
+use crate::ix_utils;
 use crate::state::bank::BankImpl;
 use crate::state::marginfi_group::MarginfiGroupImpl;
 use crate::{bank_signer, math_error, MarginfiResult};
@@ -253,6 +254,7 @@ pub fn lending_pool_withdraw_fees<'info>(
     mut ctx: Context<'info, LendingPoolWithdrawFees<'info>>,
     amount: u64,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
     let LendingPoolWithdrawFees {
         bank: bank_loader,
         fee_vault,
@@ -326,12 +328,16 @@ pub struct LendingPoolWithdrawFees<'info> {
     pub dst_token_account: InterfaceAccount<'info, TokenAccount>,
 
     pub token_program: Interface<'info, TokenInterface>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 pub fn lending_pool_withdraw_insurance<'info>(
     mut ctx: Context<'info, LendingPoolWithdrawInsurance<'info>>,
     amount: u64,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
     let LendingPoolWithdrawInsurance {
         bank: bank_loader,
         insurance_vault,
@@ -406,12 +412,16 @@ pub struct LendingPoolWithdrawInsurance<'info> {
     pub dst_token_account: InterfaceAccount<'info, TokenAccount>,
 
     pub token_program: Interface<'info, TokenInterface>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 /// Fees will be withdrawn to fees_destination_account
 pub fn lending_pool_update_fees_destination_account<'info>(
     ctx: Context<'info, LendingPoolUpdateFeesDestinationAccount<'info>>,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
     let mut bank = ctx.accounts.bank.load_mut()?;
 
     let old_dst = bank.fees_destination_account;
@@ -446,6 +456,9 @@ pub struct LendingPoolUpdateFeesDestinationAccount<'info> {
             @ MarginfiError::InvalidFeesDestinationAccount
     )]
     pub destination_account: InterfaceAccount<'info, TokenAccount>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 pub fn lending_pool_withdraw_fees_permissionless<'info>(

--- a/programs/marginfi/src/instructions/marginfi_group/config_bank_emode.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/config_bank_emode.rs
@@ -67,6 +67,7 @@ pub struct LendingPoolConfigureBankEmode<'info> {
     )]
     pub bank: AccountLoader<'info, Bank>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/config_bank_emode.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/config_bank_emode.rs
@@ -1,3 +1,4 @@
+use crate::ix_utils;
 use crate::state::emode::EmodeSettingsImpl;
 use crate::MarginfiError;
 use crate::MarginfiResult;
@@ -9,6 +10,8 @@ pub fn lending_pool_configure_bank_emode(
     emode_tag: u16,
     entries: [EmodeEntry; MAX_EMODE_ENTRIES],
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut bank = ctx.accounts.bank.load_mut()?;
     let group = ctx.accounts.group.load()?;
 
@@ -63,4 +66,7 @@ pub struct LendingPoolConfigureBankEmode<'info> {
         has_one = group @ MarginfiError::InvalidGroup,
     )]
     pub bank: AccountLoader<'info, Bank>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/config_bank_oracle.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/config_bank_oracle.rs
@@ -166,6 +166,7 @@ pub struct LendingPoolConfigureBankOracle<'info> {
     )]
     pub bank: AccountLoader<'info, Bank>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/config_bank_oracle.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/config_bank_oracle.rs
@@ -1,4 +1,5 @@
 use crate::events::{GroupEventHeader, LendingPoolBankConfigureOracleEvent};
+use crate::ix_utils;
 use crate::state::bank::BankImpl;
 use crate::state::bank_config::BankConfigImpl;
 use crate::{check, MarginfiError, MarginfiResult};
@@ -12,6 +13,8 @@ pub fn lending_pool_configure_bank_oracle(
     setup: u8,
     oracle: Pubkey,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut bank = ctx.accounts.bank.load_mut()?;
 
     // If settings are frozen, you can only update the deposit and borrow limits, so this ix will fail
@@ -162,4 +165,7 @@ pub struct LendingPoolConfigureBankOracle<'info> {
         has_one = group @ MarginfiError::InvalidGroup,
     )]
     pub bank: AccountLoader<'info, Bank>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/config_bank_oracle.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/config_bank_oracle.rs
@@ -109,6 +109,8 @@ pub fn lending_pool_configure_bank_oracle_scope(
     oracle: Pubkey,
     entry_index: u16,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut bank = ctx.accounts.bank.load_mut()?;
 
     if bank.get_flag(FREEZE_SETTINGS) {

--- a/programs/marginfi/src/instructions/marginfi_group/config_bank_premium.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/config_bank_premium.rs
@@ -1,4 +1,5 @@
 use crate::events::{GroupEventHeader, LendingPoolBankPremiumConfigureEvent};
+use crate::ix_utils;
 use crate::MarginfiError;
 use crate::MarginfiResult;
 use anchor_lang::prelude::*;
@@ -25,6 +26,8 @@ pub fn lending_pool_configure_bank_premium(
     premium_tag: u16,
     active: bool,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut bank = ctx.accounts.bank.load_mut()?;
 
     bank.premium_tag = premium_tag;
@@ -80,4 +83,8 @@ pub struct LendingPoolConfigureBankPremium<'info> {
         has_one = group @ MarginfiError::InvalidGroup,
     )]
     pub bank: AccountLoader<'info, Bank>,
+
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/config_group_fee.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/config_group_fee.rs
@@ -1,4 +1,4 @@
-use crate::{state::marginfi_group::MarginfiGroupImpl, MarginfiError, MarginfiResult};
+use crate::{ix_utils, state::marginfi_group::MarginfiGroupImpl, MarginfiError, MarginfiResult};
 use anchor_lang::prelude::*;
 use marginfi_type_crate::{
     constants::FEE_STATE_SEED,
@@ -20,9 +20,14 @@ pub struct ConfigGroupFee<'info> {
         has_one = global_fee_admin @ MarginfiError::Unauthorized
     )]
     pub fee_state: AccountLoader<'info, FeeState>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 pub fn config_group_fee(ctx: Context<ConfigGroupFee>, enable_program_fee: bool) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut marginfi_group = ctx.accounts.marginfi_group.load_mut()?;
     let flag_before = marginfi_group.group_flags;
 

--- a/programs/marginfi/src/instructions/marginfi_group/config_group_fee.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/config_group_fee.rs
@@ -21,7 +21,8 @@ pub struct ConfigGroupFee<'info> {
     )]
     pub fee_state: AccountLoader<'info, FeeState>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 

--- a/programs/marginfi/src/instructions/marginfi_group/config_group_premium.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/config_group_premium.rs
@@ -1,5 +1,6 @@
 use crate::check;
 use crate::events::{GroupEventHeader, LendingPoolGroupPremiumConfigureEvent};
+use crate::ix_utils;
 use crate::MarginfiError;
 use crate::MarginfiResult;
 use anchor_lang::prelude::*;
@@ -20,6 +21,8 @@ pub fn lending_pool_configure_group_premium(
     liability_tag: u16,
     rate: u32,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     // Zero (untagged) never matches a lookup, so storing it would create a dead entry.
     check!(
         collateral_tag != PREMIUM_TAG_EMPTY && liability_tag != PREMIUM_TAG_EMPTY,
@@ -107,4 +110,8 @@ pub struct LendingPoolConfigureGroupPremium<'info> {
     pub group: AccountLoader<'info, MarginfiGroup>,
 
     pub emode_admin: Signer<'info>,
+
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/configure.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure.rs
@@ -1,7 +1,7 @@
 use crate::events::{GroupEventHeader, MarginfiGroupConfigureEvent};
 use crate::state::marginfi_group::MarginfiGroupImpl;
 use crate::utils::i80f48_to_f64;
-use crate::{MarginfiError, MarginfiResult};
+use crate::{ix_utils, MarginfiError, MarginfiResult};
 use anchor_lang::prelude::*;
 use fixed::types::I80F48;
 use marginfi_type_crate::types::{basis_to_u32, u32_to_basis, MarginfiGroup, WrappedI80F48};
@@ -51,6 +51,8 @@ pub fn configure(
     same_asset_emode_init_leverage: Option<WrappedI80F48>,
     same_asset_emode_maint_leverage: Option<WrappedI80F48>,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let marginfi_group = &mut ctx.accounts.marginfi_group.load_mut()?;
     if let Some(new_admin) = new_admin {
         marginfi_group.update_admin(new_admin);
@@ -164,4 +166,7 @@ pub struct MarginfiGroupConfigure<'info> {
     pub marginfi_group: AccountLoader<'info, MarginfiGroup>,
 
     pub admin: Signer<'info>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/configure.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure.rs
@@ -167,6 +167,7 @@ pub struct MarginfiGroupConfigure<'info> {
 
     pub admin: Signer<'info>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/configure_bank.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure_bank.rs
@@ -97,7 +97,8 @@ pub struct LendingPoolConfigureBank<'info> {
     )]
     pub bank: AccountLoader<'info, Bank>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 

--- a/programs/marginfi/src/instructions/marginfi_group/configure_bank.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure_bank.rs
@@ -2,6 +2,7 @@ use crate::constants::MIN_EMISSIONS_SHARE_SUPPLY;
 use crate::events::{
     GroupEventHeader, LendingPoolBankConfigureEvent, LendingPoolBankConfigureFrozenEvent,
 };
+use crate::ix_utils;
 use crate::prelude::MarginfiError;
 use crate::state::bank::BankImpl;
 use crate::state::emode::EmodeSettingsImpl;
@@ -21,6 +22,8 @@ pub fn lending_pool_configure_bank(
     ctx: Context<LendingPoolConfigureBank>,
     bank_config: BankConfigOpt,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut bank = ctx.accounts.bank.load_mut()?;
 
     // If settings are frozen, you can only update the deposit and borrow limits, everything else is ignored.
@@ -93,6 +96,9 @@ pub struct LendingPoolConfigureBank<'info> {
         has_one = group @ MarginfiError::InvalidGroup,
     )]
     pub bank: AccountLoader<'info, Bank>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 /// Permissionlessly deposit same-mint emissions directly into the bank liquidity vault,

--- a/programs/marginfi/src/instructions/marginfi_group/configure_bank_lite.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure_bank_lite.rs
@@ -1,3 +1,4 @@
+use crate::ix_utils;
 use crate::set_if_some;
 use crate::state::bank::BankImpl;
 use crate::state::interest_rate::InterestRateConfigImpl;
@@ -13,6 +14,8 @@ pub fn lending_pool_configure_bank_interest_only(
     ctx: Context<LendingPoolConfigureBankInterestOnly>,
     interest_rate_config: InterestRateConfigOpt,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut bank = ctx.accounts.bank.load_mut()?;
     msg!(
         "Configuring bank: {:?} mint: {:?}",
@@ -48,6 +51,9 @@ pub struct LendingPoolConfigureBankInterestOnly<'info> {
         has_one = group @ MarginfiError::InvalidGroup,
     )]
     pub bank: AccountLoader<'info, Bank>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 pub fn lending_pool_configure_bank_limits_only(
@@ -56,6 +62,8 @@ pub fn lending_pool_configure_bank_limits_only(
     borrow_limit: Option<u64>,
     total_asset_value_init_limit: Option<u64>,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut bank = ctx.accounts.bank.load_mut()?;
     msg!(
         "Configuring bank: {:?} mint: {:?}",
@@ -97,11 +105,15 @@ pub struct LendingPoolConfigureBankLimitsOnly<'info> {
         has_one = group @ MarginfiError::InvalidGroup,
     )]
     pub bank: AccountLoader<'info, Bank>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 pub fn lending_pool_force_tokenless_repay_complete(
     ctx: Context<LendingPoolForceTokenlessRepayComplete>,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
     let mut bank = ctx.accounts.bank.load_mut()?;
 
     if bank.get_flag(TOKENLESS_REPAYMENTS_ALLOWED) {
@@ -125,4 +137,7 @@ pub struct LendingPoolForceTokenlessRepayComplete<'info> {
         has_one = group @ MarginfiError::InvalidGroup,
     )]
     pub bank: AccountLoader<'info, Bank>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/configure_bank_lite.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure_bank_lite.rs
@@ -52,7 +52,8 @@ pub struct LendingPoolConfigureBankInterestOnly<'info> {
     )]
     pub bank: AccountLoader<'info, Bank>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
@@ -106,7 +107,8 @@ pub struct LendingPoolConfigureBankLimitsOnly<'info> {
     )]
     pub bank: AccountLoader<'info, Bank>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
@@ -138,6 +140,7 @@ pub struct LendingPoolForceTokenlessRepayComplete<'info> {
     )]
     pub bank: AccountLoader<'info, Bank>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/configure_rate_limits.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure_rate_limits.rs
@@ -66,7 +66,8 @@ pub struct ConfigureBankRateLimits<'info> {
     )]
     pub bank: AccountLoader<'info, Bank>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
@@ -125,6 +126,7 @@ pub struct ConfigureGroupRateLimits<'info> {
 
     pub admin: Signer<'info>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/configure_rate_limits.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure_rate_limits.rs
@@ -1,5 +1,5 @@
 use crate::{
-    check,
+    check, ix_utils,
     state::marginfi_group::MarginfiGroupImpl,
     state::rate_limiter::{is_valid_rate_limit_amount, BankRateLimiterImpl, GroupRateLimiterImpl},
     MarginfiError, MarginfiResult,
@@ -21,6 +21,7 @@ pub fn configure_bank_rate_limits(
     hourly_max_outflow: Option<u64>,
     daily_max_outflow: Option<u64>,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
     let mut bank = ctx.accounts.bank.load_mut()?;
     let clock = Clock::get()?;
 
@@ -64,6 +65,9 @@ pub struct ConfigureBankRateLimits<'info> {
         has_one = group @ MarginfiError::InvalidGroup,
     )]
     pub bank: AccountLoader<'info, Bank>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 /// Configure group-level rate limits for aggregate withdraw/borrow operations.
@@ -82,6 +86,7 @@ pub fn configure_group_rate_limits(
     hourly_max_outflow_usd: Option<u64>,
     daily_max_outflow_usd: Option<u64>,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
     let mut group = ctx.accounts.marginfi_group.load_mut()?;
     let clock = Clock::get()?;
 
@@ -119,4 +124,7 @@ pub struct ConfigureGroupRateLimits<'info> {
     pub marginfi_group: AccountLoader<'info, MarginfiGroup>,
 
     pub admin: Signer<'info>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/configure_withdrawal_limit.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure_withdrawal_limit.rs
@@ -1,5 +1,6 @@
 use crate::{
-    check, errors::MarginfiError, state::marginfi_group::MarginfiGroupImpl, MarginfiResult,
+    check, errors::MarginfiError, ix_utils, state::marginfi_group::MarginfiGroupImpl,
+    MarginfiResult,
 };
 use anchor_lang::prelude::*;
 use marginfi_type_crate::types::MarginfiGroup;
@@ -8,6 +9,8 @@ pub fn configure_deleverage_withdrawal_limit(
     ctx: Context<ConfigureDeleverageWithdrawalLimit>,
     daily_withdrawal_limit: u32,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut marginfi_group = ctx.accounts.marginfi_group.load_mut()?;
 
     check!(
@@ -39,4 +42,7 @@ pub struct ConfigureDeleverageWithdrawalLimit<'info> {
     pub marginfi_group: AccountLoader<'info, MarginfiGroup>,
 
     pub admin: Signer<'info>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/configure_withdrawal_limit.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure_withdrawal_limit.rs
@@ -43,6 +43,7 @@ pub struct ConfigureDeleverageWithdrawalLimit<'info> {
 
     pub admin: Signer<'info>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/edit_fee_state_premium.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/edit_fee_state_premium.rs
@@ -1,4 +1,5 @@
 // Global fee admin calls this to edit the variable-borrow premium fields on the fee state.
+use crate::ix_utils;
 use crate::MarginfiError;
 use anchor_lang::prelude::*;
 use marginfi_type_crate::{constants::FEE_STATE_SEED, types::FeeState};
@@ -7,6 +8,8 @@ pub fn edit_fee_state_premium(
     ctx: Context<EditFeeStatePremium>,
     premium_wallet: Pubkey,
 ) -> Result<()> {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut fee_state = ctx.accounts.fee_state.load_mut()?;
     msg!(
         "Updating premium_wallet: {:?} -> {:?}",
@@ -31,4 +34,8 @@ pub struct EditFeeStatePremium<'info> {
         has_one = global_fee_admin @ MarginfiError::Unauthorized
     )]
     pub fee_state: AccountLoader<'info, FeeState>,
+
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/edit_global_fee.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/edit_global_fee.rs
@@ -131,6 +131,7 @@ pub struct EditFeeState<'info> {
     )]
     pub fee_state: AccountLoader<'info, FeeState>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/edit_global_fee.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/edit_global_fee.rs
@@ -1,4 +1,5 @@
 // Global fee admin calls this to edit fee state fields (all optional).
+use crate::ix_utils;
 use crate::utils::wrapped_i80f48_to_f64;
 use crate::MarginfiError;
 use anchor_lang::prelude::*;
@@ -21,6 +22,8 @@ pub fn edit_fee_state(
     pause_delegate_admin: Option<Pubkey>,
     account_transfer_fee: Option<u32>,
 ) -> Result<()> {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut fee_state = ctx.accounts.fee_state.load_mut()?;
     if let Some(admin) = admin {
         msg!(
@@ -127,4 +130,7 @@ pub struct EditFeeState<'info> {
         has_one = global_fee_admin @ MarginfiError::Unauthorized
     )]
     pub fee_state: AccountLoader<'info, FeeState>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/edit_stake_settings.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/edit_stake_settings.rs
@@ -61,7 +61,8 @@ pub struct EditStakedSettings<'info> {
     )]
     pub staked_settings: AccountLoader<'info, StakedSettings>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 

--- a/programs/marginfi/src/instructions/marginfi_group/edit_stake_settings.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/edit_stake_settings.rs
@@ -2,6 +2,7 @@ use crate::events::EditStakedSettingsEvent;
 use crate::state::staked_settings::StakedSettingsImpl;
 // Used by the group admin to edit the default features of staked collateral banks. Remember to
 // propagate afterwards.
+use crate::ix_utils;
 use crate::set_if_some;
 use crate::MarginfiError;
 use anchor_lang::prelude::*;
@@ -11,6 +12,8 @@ pub fn edit_staked_settings(
     ctx: Context<EditStakedSettings>,
     settings: StakedSettingsEditConfig,
 ) -> Result<()> {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     // let group = ctx.accounts.marginfi_group.load()?;
     let mut staked_settings = ctx.accounts.staked_settings.load_mut()?;
     // require_keys_eq!(group.admin, ctx.accounts.admin.key());
@@ -57,6 +60,9 @@ pub struct EditStakedSettings<'info> {
         has_one = marginfi_group @ MarginfiError::InvalidGroup
     )]
     pub staked_settings: AccountLoader<'info, StakedSettings>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 #[derive(AnchorDeserialize, AnchorSerialize, Default)]

--- a/programs/marginfi/src/instructions/marginfi_group/emode_clone.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/emode_clone.rs
@@ -44,6 +44,7 @@ pub struct LendingPoolCloneEmode<'info> {
     )]
     pub copy_to_bank: AccountLoader<'info, Bank>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/emode_clone.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/emode_clone.rs
@@ -1,9 +1,11 @@
-use crate::{check, MarginfiError, MarginfiResult};
+use crate::{check, ix_utils, MarginfiError, MarginfiResult};
 use anchor_lang::prelude::*;
 use marginfi_type_crate::types::{Bank, MarginfiGroup};
 
 /// Copy emode settings from one bank to another within the same group.
 pub fn lending_pool_clone_emode(ctx: Context<LendingPoolCloneEmode>) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let group = ctx.accounts.group.load()?;
 
     check!(
@@ -41,4 +43,7 @@ pub struct LendingPoolCloneEmode<'info> {
         has_one = group @ MarginfiError::InvalidGroup,
     )]
     pub copy_to_bank: AccountLoader<'info, Bank>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/handle_bankruptcy.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/handle_bankruptcy.rs
@@ -320,6 +320,7 @@ pub struct LendingPoolHandleBankruptcy<'info> {
 
     pub token_program: Interface<'info, TokenInterface>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/handle_bankruptcy.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/handle_bankruptcy.rs
@@ -3,7 +3,7 @@ use crate::{
     constants::PROGRAM_VERSION,
     debug,
     events::{AccountEventHeader, LendingPoolBankHandleBankruptcyEvent},
-    math_error,
+    ix_utils, math_error,
     prelude::MarginfiError,
     state::{
         bank::BankImpl,
@@ -41,6 +41,8 @@ use std::cmp::{max, min};
 pub fn lending_pool_handle_bankruptcy<'info>(
     mut ctx: Context<'info, LendingPoolHandleBankruptcy<'info>>,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let LendingPoolHandleBankruptcy {
         marginfi_account: marginfi_account_loader,
         insurance_vault,
@@ -317,4 +319,7 @@ pub struct LendingPoolHandleBankruptcy<'info> {
     pub insurance_vault_authority: UncheckedAccount<'info>,
 
     pub token_program: Interface<'info, TokenInterface>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/init_same_asset_emode_registry.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/init_same_asset_emode_registry.rs
@@ -1,4 +1,4 @@
-use crate::{check, MarginfiError, MarginfiResult};
+use crate::{check, ix_utils, MarginfiError, MarginfiResult};
 use anchor_lang::prelude::*;
 use marginfi_type_crate::{
     constants::SAME_ASSET_EMODE_REGISTRY_SEED,
@@ -12,6 +12,8 @@ use marginfi_type_crate::{
 pub fn lending_pool_init_same_asset_emode_registry(
     ctx: Context<LendingPoolInitSameAssetEmodeRegistry>,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let group = ctx.accounts.group.load()?;
 
     check!(
@@ -49,4 +51,7 @@ pub struct LendingPoolInitSameAssetEmodeRegistry<'info> {
     pub same_asset_emode_registry: AccountLoader<'info, SameAssetEmodeRegistry>,
 
     pub system_program: Program<'info, System>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/init_same_asset_emode_registry.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/init_same_asset_emode_registry.rs
@@ -52,6 +52,7 @@ pub struct LendingPoolInitSameAssetEmodeRegistry<'info> {
 
     pub system_program: Program<'info, System>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/init_staked_settings.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/init_staked_settings.rs
@@ -76,7 +76,8 @@ pub struct InitStakedSettings<'info> {
 
     pub system_program: Program<'info, System>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 

--- a/programs/marginfi/src/instructions/marginfi_group/init_staked_settings.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/init_staked_settings.rs
@@ -1,4 +1,5 @@
 // Used by the group admin to enable staked collateral banks and configure their default features
+use crate::ix_utils;
 use crate::state::staked_settings::StakedSettingsImpl;
 use crate::utils::wrapped_i80f48_to_f64;
 use crate::MarginfiError;
@@ -12,6 +13,8 @@ pub fn initialize_staked_settings(
     ctx: Context<InitStakedSettings>,
     settings: StakedSettingsConfig,
 ) -> Result<()> {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut staked_settings = ctx.accounts.staked_settings.load_init()?;
 
     *staked_settings = StakedSettings::new(
@@ -72,6 +75,9 @@ pub struct InitStakedSettings<'info> {
     pub staked_settings: AccountLoader<'info, StakedSettings>,
 
     pub system_program: Program<'info, System>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 #[derive(AnchorDeserialize, AnchorSerialize, Default)]

--- a/programs/marginfi/src/instructions/marginfi_group/initialize.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/initialize.rs
@@ -1,6 +1,6 @@
 use crate::events::{GroupEventHeader, MarginfiGroupCreateEvent};
 use crate::state::marginfi_group::MarginfiGroupImpl;
-use crate::MarginfiResult;
+use crate::{ix_utils, MarginfiResult};
 use anchor_lang::prelude::*;
 use marginfi_type_crate::{
     constants::FEE_STATE_SEED,
@@ -8,6 +8,8 @@ use marginfi_type_crate::{
 };
 
 pub fn initialize_group(ctx: Context<MarginfiGroupInitialize>) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let marginfi_group = &mut ctx.accounts.marginfi_group.load_init()?;
 
     marginfi_group.set_initial_configuration(ctx.accounts.admin.key());
@@ -69,4 +71,7 @@ pub struct MarginfiGroupInitialize<'info> {
     pub fee_state: AccountLoader<'info, FeeState>,
 
     pub system_program: Program<'info, System>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/initialize.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/initialize.rs
@@ -72,6 +72,7 @@ pub struct MarginfiGroupInitialize<'info> {
 
     pub system_program: Program<'info, System>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/on_ramp_transition.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/on_ramp_transition.rs
@@ -1,4 +1,4 @@
-use crate::{MarginfiError, MarginfiResult};
+use crate::{ix_utils, MarginfiError, MarginfiResult};
 use anchor_lang::prelude::*;
 use marginfi_type_crate::{
     constants::{STAKED_ORACLE_DISABLED, STAKED_ORACLE_PRICE_USES_ONRAMP, STAKED_SETTINGS_SEED},
@@ -7,6 +7,8 @@ use marginfi_type_crate::{
 
 // To be removed once SVSP update is rolled out (likely in 1.10)
 pub fn disable_staked_oracles(ctx: Context<DisableStakedOracles>) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut staked_settings = ctx.accounts.staked_settings.load_mut()?;
 
     staked_settings.flags &= !STAKED_ORACLE_PRICE_USES_ONRAMP;
@@ -35,10 +37,15 @@ pub struct DisableStakedOracles<'info> {
             @ MarginfiError::InvalidGroup
     )]
     pub staked_settings: AccountLoader<'info, StakedSettings>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 // To be removed once SVSP update is rolled out (likely in 1.10)
 pub fn enable_staked_oracle_onramp(ctx: Context<EnableStakedOracleOnramp>) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut staked_settings = ctx.accounts.staked_settings.load_mut()?;
 
     staked_settings.flags &= !STAKED_ORACLE_DISABLED;
@@ -67,4 +74,7 @@ pub struct EnableStakedOracleOnramp<'info> {
             @ MarginfiError::InvalidGroup
     )]
     pub staked_settings: AccountLoader<'info, StakedSettings>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/on_ramp_transition.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/on_ramp_transition.rs
@@ -38,7 +38,8 @@ pub struct DisableStakedOracles<'info> {
     )]
     pub staked_settings: AccountLoader<'info, StakedSettings>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
@@ -75,6 +76,7 @@ pub struct EnableStakedOracleOnramp<'info> {
     )]
     pub staked_settings: AccountLoader<'info, StakedSettings>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/panic_pause.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/panic_pause.rs
@@ -47,6 +47,7 @@ pub struct PanicPause<'info> {
     )]
     pub fee_state: AccountLoader<'info, FeeState>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/panic_pause.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/panic_pause.rs
@@ -1,3 +1,4 @@
+use crate::ix_utils;
 use crate::state::{fee_state::FeeStateImpl, panic_state::PanicStateImpl};
 use crate::MarginfiError;
 use anchor_lang::prelude::*;
@@ -5,6 +6,8 @@ use marginfi_type_crate::constants::FEE_STATE_SEED;
 use marginfi_type_crate::types::{FeeState, PanicState};
 
 pub fn panic_pause(ctx: Context<PanicPause>) -> Result<()> {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut fee_state = ctx.accounts.fee_state.load_mut()?;
     let current_timestamp = Clock::get()?.unix_timestamp;
 
@@ -43,4 +46,7 @@ pub struct PanicPause<'info> {
         constraint = fee_state.load()?.is_pause_authority(pause_authority.key()) @ MarginfiError::Unauthorized
     )]
     pub fee_state: AccountLoader<'info, FeeState>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/panic_unpause.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/panic_unpause.rs
@@ -53,6 +53,7 @@ pub struct PanicUnpause<'info> {
     )]
     pub fee_state: AccountLoader<'info, FeeState>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/panic_unpause.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/panic_unpause.rs
@@ -1,10 +1,13 @@
 use anchor_lang::prelude::*;
 use marginfi_type_crate::{constants::FEE_STATE_SEED, types::FeeState};
 
+use crate::ix_utils;
 use crate::state::panic_state::PanicStateImpl;
 use crate::MarginfiError;
 
 pub fn panic_unpause(ctx: Context<PanicUnpause>) -> Result<()> {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut fee_state = ctx.accounts.fee_state.load_mut()?;
     let current_timestamp = Clock::get()?.unix_timestamp;
 
@@ -49,4 +52,7 @@ pub struct PanicUnpause<'info> {
         has_one = global_fee_admin @ MarginfiError::Unauthorized
     )]
     pub fee_state: AccountLoader<'info, FeeState>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/set_bank_same_asset_emode.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/set_bank_same_asset_emode.rs
@@ -169,6 +169,7 @@ pub struct LendingPoolSetBankSameAssetEmodeEligibility<'info> {
     )]
     pub same_asset_emode_registry: AccountLoader<'info, SameAssetEmodeRegistry>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/set_bank_same_asset_emode.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/set_bank_same_asset_emode.rs
@@ -1,4 +1,5 @@
 use crate::events::{GroupEventHeader, LendingPoolBankSetSameAssetEmodeEligibilityEvent};
+use crate::ix_utils;
 use crate::state::bank::BankImpl;
 use crate::{check, MarginfiError, MarginfiResult};
 use anchor_lang::prelude::*;
@@ -19,6 +20,8 @@ pub fn lending_pool_set_bank_same_asset_emode_eligibility(
     ctx: Context<LendingPoolSetBankSameAssetEmodeEligibility>,
     enabled: bool,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let group = ctx.accounts.group.load()?;
 
     check!(
@@ -165,4 +168,7 @@ pub struct LendingPoolSetBankSameAssetEmodeEligibility<'info> {
         bump,
     )]
     pub same_asset_emode_registry: AccountLoader<'info, SameAssetEmodeRegistry>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/set_oracle_price.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/set_oracle_price.rs
@@ -1,4 +1,5 @@
 use crate::events::{GroupEventHeader, LendingPoolBankSetOraclePriceEvent};
+use crate::ix_utils;
 use crate::state::bank::BankImpl;
 use crate::state::bank_config::BankConfigImpl;
 use crate::{check, errors::MarginfiError, MarginfiResult};
@@ -30,6 +31,8 @@ pub fn lending_pool_set_oracle_price(
     price: WrappedI80F48,
     setup: u8,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut bank = ctx.accounts.bank.load_mut()?;
 
     if bank.get_flag(FREEZE_SETTINGS) {
@@ -136,4 +139,8 @@ pub struct LendingPoolSetOraclePrice<'info> {
         has_one = group
     )]
     pub bank: AccountLoader<'info, Bank>,
+
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/super_admin_deposit.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/super_admin_deposit.rs
@@ -137,6 +137,7 @@ pub struct SuperAdminDeposit<'info> {
 
     pub token_program: Interface<'info, TokenInterface>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/super_admin_deposit.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/super_admin_deposit.rs
@@ -2,7 +2,7 @@ use crate::{
     check,
     constants::{LOCALNET_ID, MAINNET_PROGRAM_ID, STAGING_ID},
     events::{GroupEventHeader, LendingPoolSuperAdminDepositEvent},
-    math_error,
+    ix_utils, math_error,
     prelude::{MarginfiError, MarginfiResult},
     state::bank::BankImpl,
     utils,
@@ -27,6 +27,8 @@ pub fn super_admin_deposit<'info>(
     mut ctx: Context<'info, SuperAdminDeposit<'info>>,
     amount: u64,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     if crate::ID != STAGING_ID && crate::ID != LOCALNET_ID {
         panic!("Staging or localnet only!");
     }
@@ -48,6 +50,7 @@ pub fn super_admin_deposit<'info>(
         admin_token_account,
         liquidity_vault,
         token_program,
+        instruction_sysvar: _,
     } = &ctx.accounts;
 
     let maybe_bank_mint = {
@@ -133,4 +136,7 @@ pub struct SuperAdminDeposit<'info> {
     pub liquidity_vault: InterfaceAccount<'info, TokenAccount>,
 
     pub token_program: Interface<'info, TokenInterface>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/super_admin_withdraw.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/super_admin_withdraw.rs
@@ -180,6 +180,7 @@ pub struct SuperAdminWithdraw<'info> {
 
     pub token_program: Interface<'info, TokenInterface>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/super_admin_withdraw.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/super_admin_withdraw.rs
@@ -2,7 +2,7 @@ use crate::{
     bank_signer, check,
     constants::{LOCALNET_ID, MAINNET_PROGRAM_ID, STAGING_ID},
     events::{GroupEventHeader, LendingPoolSuperAdminWithdrawEvent},
-    live, math_error,
+    ix_utils, live, math_error,
     prelude::{MarginfiError, MarginfiResult},
     state::bank::BankImpl,
     utils,
@@ -31,6 +31,8 @@ pub fn super_admin_withdraw<'info>(
     mut ctx: Context<'info, SuperAdminWithdraw<'info>>,
     amount: u64,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     if crate::ID != STAGING_ID && crate::ID != LOCALNET_ID {
         panic!("Staging or localnet only!");
     }
@@ -53,6 +55,7 @@ pub fn super_admin_withdraw<'info>(
         liquidity_vault_authority,
         token_program,
         admin,
+        instruction_sysvar: _,
     } = &ctx.accounts;
 
     let maybe_bank_mint = {
@@ -176,4 +179,7 @@ pub struct SuperAdminWithdraw<'info> {
     pub liquidity_vault: InterfaceAccount<'info, TokenAccount>,
 
     pub token_program: Interface<'info, TokenInterface>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/update_deleverage_withdrawals.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/update_deleverage_withdrawals.rs
@@ -91,7 +91,8 @@ pub struct UpdateDeleverageWithdrawals<'info> {
 
     pub delegate_flow_admin: Signer<'info>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 

--- a/programs/marginfi/src/instructions/marginfi_group/update_deleverage_withdrawals.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/update_deleverage_withdrawals.rs
@@ -1,4 +1,6 @@
-use crate::{check, state::marginfi_group::MarginfiGroupImpl, MarginfiError, MarginfiResult};
+use crate::{
+    check, ix_utils, state::marginfi_group::MarginfiGroupImpl, MarginfiError, MarginfiResult,
+};
 use anchor_lang::prelude::*;
 use fixed::types::I80F48;
 use marginfi_type_crate::types::MarginfiGroup;
@@ -19,6 +21,8 @@ pub fn update_deleverage_withdrawals(
     event_start_slot: u64,
     event_end_slot: u64,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut group = ctx.accounts.marginfi_group.load_mut()?;
     let clock = Clock::get()?;
 
@@ -86,6 +90,9 @@ pub struct UpdateDeleverageWithdrawals<'info> {
     pub marginfi_group: AccountLoader<'info, MarginfiGroup>,
 
     pub delegate_flow_admin: Signer<'info>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 #[cfg(test)]

--- a/programs/marginfi/src/instructions/marginfi_group/update_group_rate_limiter.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/update_group_rate_limiter.rs
@@ -103,7 +103,8 @@ pub struct UpdateGroupRateLimiter<'info> {
 
     pub delegate_flow_admin: Signer<'info>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 

--- a/programs/marginfi/src/instructions/marginfi_group/update_group_rate_limiter.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/update_group_rate_limiter.rs
@@ -1,5 +1,5 @@
 use crate::{
-    check,
+    check, ix_utils,
     state::rate_limiter::{is_valid_rate_limit_amount, GroupRateLimiterImpl},
     MarginfiError, MarginfiResult,
 };
@@ -24,6 +24,8 @@ pub fn update_group_rate_limiter(
     event_start_slot: u64,
     event_end_slot: u64,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
+
     let mut group = ctx.accounts.marginfi_group.load_mut()?;
     let clock = Clock::get()?;
 
@@ -100,6 +102,9 @@ pub struct UpdateGroupRateLimiter<'info> {
     pub marginfi_group: AccountLoader<'info, MarginfiGroup>,
 
     pub delegate_flow_admin: Signer<'info>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 #[cfg(test)]

--- a/programs/marginfi/src/instructions/marginfi_group/write_bank_metadata.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/write_bank_metadata.rs
@@ -108,7 +108,8 @@ pub struct WriteBankMetadata<'info> {
     #[account(mut, has_one = bank)]
     pub metadata: AccountLoader<'info, BankMetadata>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
@@ -138,6 +139,7 @@ pub struct WriteBankMetadataPreInit<'info> {
     #[account(mut, has_one = bank)]
     pub metadata: AccountLoader<'info, BankMetadata>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/write_bank_metadata.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/write_bank_metadata.rs
@@ -4,13 +4,14 @@ use marginfi_type_crate::{
     types::{Bank, BankMetadata, MarginfiGroup},
 };
 
-use crate::{check_eq, MarginfiError};
+use crate::{check_eq, ix_utils, MarginfiError};
 
 pub fn write_bank_metadata(
     ctx: Context<WriteBankMetadata>,
     ticker: Option<Vec<u8>>,
     description: Option<Vec<u8>>,
 ) -> Result<()> {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
     // When the bank's seed is on-chain, recompute the canonical PDA and verify the passed bank
     // account matches it. Legacy keypair banks (BANK_SEED_KNOWN unset) skip the check.
     {
@@ -42,6 +43,7 @@ pub fn write_bank_metadata_pre_init(
     ticker: Option<Vec<u8>>,
     description: Option<Vec<u8>>,
 ) -> Result<()> {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
     let mut metadata = ctx.accounts.metadata.load_mut()?;
     apply_metadata_write(&mut metadata, ticker, description)
 }
@@ -105,6 +107,9 @@ pub struct WriteBankMetadata<'info> {
 
     #[account(mut, has_one = bank)]
     pub metadata: AccountLoader<'info, BankMetadata>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }
 
 #[derive(Accounts)]
@@ -132,4 +137,7 @@ pub struct WriteBankMetadataPreInit<'info> {
 
     #[account(mut, has_one = bank)]
     pub metadata: AccountLoader<'info, BankMetadata>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/solend/add_pool.rs
+++ b/programs/marginfi/src/instructions/solend/add_pool.rs
@@ -1,3 +1,4 @@
+use crate::ix_utils;
 // Adds a Solend type bank to a group with sane defaults. Used to integrate with Solend
 // allowing users to interact with Solend pools through marginfi
 use crate::{
@@ -25,6 +26,7 @@ pub fn lending_pool_add_bank_solend(
     bank_config: SolendConfigCompact,
     bank_seed: u64,
 ) -> MarginfiResult {
+    ix_utils::check_no_durable_nonce(&ctx.accounts.instruction_sysvar)?;
     // Note: Solend banks don't need to debit the flat SOL fee because these will always be
     // first-party pools owned by mrgn and never permissionless pools
     let LendingPoolAddBankSolend {
@@ -228,4 +230,7 @@ pub struct LendingPoolAddBankSolend<'info> {
 
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
+
+    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/solend/add_pool.rs
+++ b/programs/marginfi/src/instructions/solend/add_pool.rs
@@ -231,6 +231,7 @@ pub struct LendingPoolAddBankSolend<'info> {
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
 
-    #[account(address = pubkey!("Sysvar1nstructions4gQvDKZeTQvzK88j5KqVn5P"))]
+    /// CHECK: instruction sysvar
+    #[account(address = solana_instructions_sysvar::id())]
     pub instruction_sysvar: UncheckedAccount<'info>,
 }

--- a/programs/marginfi/src/ix_utils.rs
+++ b/programs/marginfi/src/ix_utils.rs
@@ -373,36 +373,27 @@ pub fn is_allowed_cpi_for_third_party_id(
     Ok(current_ixn.program_id == allowed_program)
 }
 
-pub fn check_no_durable_nonce(sysvar: &AccountInfo) -> MarginfiResult<()> {
-    let ixes = load_and_validate_instructions(sysvar, None)?;
+/// Rejects the transaction if any of its instructions is the system program's
+/// `AdvanceNonceAccount`.
+///
+/// A durable-nonce transaction is signed once and can be held for an unbounded time before it is
+/// submitted, so an admin signature would no longer reflect the admin's intent at signing time.
+/// The runtime only treats a transaction as nonced when `AdvanceNonceAccount` is instruction 0
+/// (`SanitizedMessage::get_durable_nonce`, matching on the data prefix `[4, 0, 0, 0]`), but admin
+/// operations have no reason to advance a nonce at any position, so the whole transaction is
+/// scanned rather than relying on that detail.
+pub fn check_no_durable_nonce(sysvar: &AccountInfo) -> MarginfiResult {
+    const ADVANCE_NONCE_ACCOUNT_DATA: [u8; 4] = 4u32.to_le_bytes();
 
-    if ixes.is_empty() {
-        return Ok(());
-    }
+    let advances_nonce = load_and_validate_instructions(sysvar, None)?
+        .iter()
+        .any(|ix| {
+            ix.program_id == anchor_lang::solana_program::system_program::ID
+                && ix.data.get(..4) == Some(&ADVANCE_NONCE_ACCOUNT_DATA)
+        });
+    check!(!advances_nonce, MarginfiError::DurableNonceNotAllowed);
 
-    let first_ix = &ixes[0];
-
-    if first_ix.program_id != anchor_lang::solana_program::system_program::ID {
-        return Ok(());
-    }
-
-    if first_ix.data.len() < 4 {
-        return Ok(());
-    }
-
-    const ADVANCE_NONCE_ACCOUNT_DISCRIMINATOR: u32 = 4;
-    let discriminator = u32::from_le_bytes([
-        first_ix.data[0],
-        first_ix.data[1],
-        first_ix.data[2],
-        first_ix.data[3],
-    ]);
-
-    if discriminator == ADVANCE_NONCE_ACCOUNT_DISCRIMINATOR {
-        err!(MarginfiError::DurableNonceNotAllowed)
-    } else {
-        Ok(())
-    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/programs/marginfi/src/ix_utils.rs
+++ b/programs/marginfi/src/ix_utils.rs
@@ -373,6 +373,38 @@ pub fn is_allowed_cpi_for_third_party_id(
     Ok(current_ixn.program_id == allowed_program)
 }
 
+pub fn check_no_durable_nonce(sysvar: &AccountInfo) -> MarginfiResult<()> {
+    let ixes = load_and_validate_instructions(sysvar, None)?;
+
+    if ixes.is_empty() {
+        return Ok(());
+    }
+
+    let first_ix = &ixes[0];
+
+    if first_ix.program_id != anchor_lang::solana_program::system_program::ID {
+        return Ok(());
+    }
+
+    if first_ix.data.len() < 4 {
+        return Ok(());
+    }
+
+    const ADVANCE_NONCE_ACCOUNT_DISCRIMINATOR: u32 = 4;
+    let discriminator = u32::from_le_bytes([
+        first_ix.data[0],
+        first_ix.data[1],
+        first_ix.data[2],
+        first_ix.data[3],
+    ]);
+
+    if discriminator == ADVANCE_NONCE_ACCOUNT_DISCRIMINATOR {
+        err!(MarginfiError::DurableNonceNotAllowed)
+    } else {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use marginfi_type_crate::constants::{discriminators, ix_discriminators};

--- a/programs/marginfi/tests/admin_actions/create_marginfi_group.rs
+++ b/programs/marginfi/tests/admin_actions/create_marginfi_group.rs
@@ -22,6 +22,7 @@ async fn marginfi_group_create_success() -> anyhow::Result<()> {
         admin: test_f.payer(),
         fee_state: fee_state_key,
         system_program: system_program::id(),
+        instruction_sysvar: solana_sdk::sysvar::instructions::ID,
     };
     let init_marginfi_group_ix = Instruction {
         program_id: marginfi::ID,

--- a/programs/marginfi/tests/admin_actions/deleverage_withdraw_limit.rs
+++ b/programs/marginfi/tests/admin_actions/deleverage_withdraw_limit.rs
@@ -62,6 +62,7 @@ async fn limit_admin_can_configure_and_flow_admin_can_update_deleverage_withdraw
             accounts: marginfi::accounts::ConfigureDeleverageWithdrawalLimit {
                 marginfi_group: test_f.marginfi_group.key,
                 admin: limit_admin.pubkey(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::ConfigureDeleverageWithdrawalLimit { limit: 100 }.data(),
@@ -92,6 +93,7 @@ async fn limit_admin_can_configure_and_flow_admin_can_update_deleverage_withdraw
             accounts: marginfi::accounts::UpdateDeleverageWithdrawals {
                 marginfi_group: test_f.marginfi_group.key,
                 delegate_flow_admin: flow_admin.pubkey(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::UpdateDeleverageWithdrawals {
@@ -199,6 +201,7 @@ async fn update_deleverage_withdraw_limit_guard_errors() -> anyhow::Result<()> {
             accounts: marginfi::accounts::UpdateDeleverageWithdrawals {
                 marginfi_group: test_f.marginfi_group.key,
                 delegate_flow_admin: test_f.payer(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::UpdateDeleverageWithdrawals {
@@ -235,6 +238,7 @@ async fn update_deleverage_withdraw_limit_guard_errors() -> anyhow::Result<()> {
             accounts: marginfi::accounts::UpdateDeleverageWithdrawals {
                 marginfi_group: test_f.marginfi_group.key,
                 delegate_flow_admin: test_f.payer(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::UpdateDeleverageWithdrawals {
@@ -271,6 +275,7 @@ async fn update_deleverage_withdraw_limit_guard_errors() -> anyhow::Result<()> {
             accounts: marginfi::accounts::UpdateDeleverageWithdrawals {
                 marginfi_group: test_f.marginfi_group.key,
                 delegate_flow_admin: test_f.payer(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::UpdateDeleverageWithdrawals {
@@ -307,6 +312,7 @@ async fn update_deleverage_withdraw_limit_guard_errors() -> anyhow::Result<()> {
             accounts: marginfi::accounts::UpdateDeleverageWithdrawals {
                 marginfi_group: test_f.marginfi_group.key,
                 delegate_flow_admin: test_f.payer(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::UpdateDeleverageWithdrawals {
@@ -356,6 +362,7 @@ async fn update_deleverage_withdraw_limit_guard_errors() -> anyhow::Result<()> {
             accounts: marginfi::accounts::UpdateDeleverageWithdrawals {
                 marginfi_group: test_f.marginfi_group.key,
                 delegate_flow_admin: attacker.pubkey(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::UpdateDeleverageWithdrawals {

--- a/programs/marginfi/tests/admin_actions/durable_nonce.rs
+++ b/programs/marginfi/tests/admin_actions/durable_nonce.rs
@@ -1,0 +1,133 @@
+use anchor_lang::{prelude::*, solana_program::instruction::Instruction, InstructionData};
+use fixtures::{assert_custom_error, prelude::*};
+use marginfi::errors::MarginfiError;
+use solana_program_test::*;
+use solana_sdk::{hash::Hash, signature::Keypair, signer::Signer, transaction::Transaction};
+use solana_system_interface::instruction::{advance_nonce_account, create_nonce_account};
+
+/// Serialized size of a nonce account (`solana_nonce::state::State::size()`).
+const NONCE_ACCOUNT_LEN: usize = 80;
+/// Byte range of the stored durable nonce hash inside a nonce account: `Versions` tag (4) +
+/// `State` tag (4) + authority (32), then the 32-byte hash.
+const NONCE_HASH_RANGE: std::ops::Range<usize> = 40..72;
+
+/// Clones the banks client out of the fixture so no `RefCell` borrow is held across an await.
+fn banks_client(test_f: &TestFixture) -> BanksClient {
+    test_f.context.borrow().banks_client.clone()
+}
+
+/// Creates a nonce account authorized by `authority` and returns it with its durable nonce hash,
+/// ready to be used as a transaction's `recent_blockhash`.
+async fn create_nonce(
+    test_f: &TestFixture,
+    authority: &Keypair,
+) -> anyhow::Result<(Keypair, Hash)> {
+    let nonce = Keypair::new();
+    let lamports = test_f.get_minimum_rent_for_size(NONCE_ACCOUNT_LEN).await;
+    let tx = Transaction::new_signed_with_payer(
+        &create_nonce_account(
+            &authority.pubkey(),
+            &nonce.pubkey(),
+            &authority.pubkey(),
+            lamports,
+        ),
+        Some(&authority.pubkey()),
+        &[authority, &nonce],
+        test_f.get_latest_blockhash().await,
+    );
+    banks_client(test_f).process_transaction(tx).await?;
+
+    // The runtime refuses to consume a nonce until the chain has moved past the blockhash the
+    // nonce was initialized against.
+    test_f.advance_time(1).await;
+
+    let account = banks_client(test_f)
+        .get_account(nonce.pubkey())
+        .await?
+        .expect("nonce account exists");
+    let hash = Hash::new_from_array(account.data[NONCE_HASH_RANGE].try_into()?);
+    Ok((nonce, hash))
+}
+
+fn configure_bank_premium_ix(test_f: &TestFixture, emode_admin: Pubkey) -> Instruction {
+    Instruction {
+        program_id: marginfi::ID,
+        accounts: marginfi::accounts::LendingPoolConfigureBankPremium {
+            group: test_f.marginfi_group.key,
+            emode_admin,
+            bank: test_f.get_bank(&BankMint::Usdc).key,
+            instruction_sysvar: solana_instructions_sysvar::id(),
+        }
+        .to_account_metas(Some(true)),
+        data: marginfi::instruction::LendingPoolConfigureBankPremium {
+            premium_tag: 1,
+            active: true,
+        }
+        .data(),
+    }
+}
+
+#[tokio::test]
+async fn admin_instruction_rejects_durable_nonce_transaction() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let admin = test_f.payer_keypair();
+    let (nonce, nonce_hash) = create_nonce(&test_f, &admin).await?;
+
+    let tx = Transaction::new_signed_with_payer(
+        &[
+            advance_nonce_account(&nonce.pubkey(), &admin.pubkey()),
+            configure_bank_premium_ix(&test_f, admin.pubkey()),
+        ],
+        Some(&admin.pubkey()),
+        &[&admin],
+        nonce_hash,
+    );
+    let res = banks_client(&test_f)
+        .process_transaction_with_preflight(tx)
+        .await;
+
+    assert_custom_error!(res.unwrap_err(), MarginfiError::DurableNonceNotAllowed);
+    Ok(())
+}
+
+/// The scan is not limited to instruction 0 (the only position the runtime treats as a durable
+/// nonce marker): an `AdvanceNonceAccount` anywhere in an admin transaction is rejected, even
+/// when the transaction itself uses a recent blockhash.
+#[tokio::test]
+async fn admin_instruction_rejects_advance_nonce_at_any_index() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let admin = test_f.payer_keypair();
+    let (nonce, _) = create_nonce(&test_f, &admin).await?;
+
+    let tx = Transaction::new_signed_with_payer(
+        &[
+            configure_bank_premium_ix(&test_f, admin.pubkey()),
+            advance_nonce_account(&nonce.pubkey(), &admin.pubkey()),
+        ],
+        Some(&admin.pubkey()),
+        &[&admin],
+        test_f.get_latest_blockhash().await,
+    );
+    let res = banks_client(&test_f)
+        .process_transaction_with_preflight(tx)
+        .await;
+
+    assert_custom_error!(res.unwrap_err(), MarginfiError::DurableNonceNotAllowed);
+    Ok(())
+}
+
+#[tokio::test]
+async fn admin_instruction_accepts_recent_blockhash_transaction() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let admin = test_f.payer_keypair();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[configure_bank_premium_ix(&test_f, admin.pubkey())],
+        Some(&admin.pubkey()),
+        &[&admin],
+        test_f.get_latest_blockhash().await,
+    );
+    banks_client(&test_f).process_transaction(tx).await?;
+
+    Ok(())
+}

--- a/programs/marginfi/tests/admin_actions/mod.rs
+++ b/programs/marginfi/tests/admin_actions/mod.rs
@@ -6,6 +6,7 @@ mod circuit_breaker;
 mod create_marginfi_group;
 mod deleverage;
 mod deleverage_withdraw_limit;
+mod durable_nonce;
 mod freeze;
 mod group_resize;
 mod interest_accrual;

--- a/programs/marginfi/tests/admin_actions/panic_mode.rs
+++ b/programs/marginfi/tests/admin_actions/panic_mode.rs
@@ -121,6 +121,7 @@ async fn test_pause_delegate_admin_cannot_edit_fee_state() -> anyhow::Result<()>
         accounts: marginfi::accounts::EditFeeState {
             global_fee_admin: pause_delegate_admin.pubkey(),
             fee_state: marginfi_group.fee_state,
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true)),
         data: marginfi::instruction::EditGlobalFeeState {

--- a/programs/marginfi/tests/admin_actions/rate_limiter.rs
+++ b/programs/marginfi/tests/admin_actions/rate_limiter.rs
@@ -32,6 +32,7 @@ async fn configure_group_hourly_limit_as(
         accounts: marginfi::accounts::ConfigureGroupRateLimits {
             marginfi_group: test_f.marginfi_group.key,
             admin: admin.pubkey(),
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true)),
         data: marginfi::instruction::ConfigureGroupRateLimits {
@@ -65,6 +66,7 @@ async fn configure_bank_hourly_limit_as(
         accounts: marginfi::accounts::ConfigureBankRateLimits {
             group: test_f.marginfi_group.key,
             admin: admin.pubkey(),
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             bank,
         }
         .to_account_metas(Some(true)),
@@ -97,6 +99,7 @@ async fn configure_group_hourly_limit(
         accounts: marginfi::accounts::ConfigureGroupRateLimits {
             marginfi_group: test_f.marginfi_group.key,
             admin: test_f.payer(),
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true)),
         data: marginfi::instruction::ConfigureGroupRateLimits {
@@ -172,6 +175,7 @@ async fn limit_admin_can_configure_and_flow_admin_can_update_rate_limits() -> an
         accounts: marginfi::accounts::UpdateGroupRateLimiter {
             marginfi_group: test_f.marginfi_group.key,
             delegate_flow_admin: flow_admin.pubkey(),
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true)),
         data: marginfi::instruction::UpdateGroupRateLimiter {
@@ -224,6 +228,7 @@ async fn update_group_rate_limiter_applies_inflow_before_outflow() -> anyhow::Re
             accounts: marginfi::accounts::UpdateGroupRateLimiter {
                 marginfi_group: test_f.marginfi_group.key,
                 delegate_flow_admin: test_f.payer(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::UpdateGroupRateLimiter {
@@ -266,6 +271,7 @@ async fn update_group_rate_limiter_applies_inflow_before_outflow() -> anyhow::Re
             accounts: marginfi::accounts::UpdateGroupRateLimiter {
                 marginfi_group: test_f.marginfi_group.key,
                 delegate_flow_admin: test_f.payer(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::UpdateGroupRateLimiter {
@@ -315,6 +321,7 @@ async fn update_group_rate_limiter_guard_errors() -> anyhow::Result<()> {
             accounts: marginfi::accounts::UpdateGroupRateLimiter {
                 marginfi_group: test_f.marginfi_group.key,
                 delegate_flow_admin: test_f.payer(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::UpdateGroupRateLimiter {
@@ -348,6 +355,7 @@ async fn update_group_rate_limiter_guard_errors() -> anyhow::Result<()> {
             accounts: marginfi::accounts::UpdateGroupRateLimiter {
                 marginfi_group: test_f.marginfi_group.key,
                 delegate_flow_admin: test_f.payer(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::UpdateGroupRateLimiter {
@@ -389,6 +397,7 @@ async fn update_group_rate_limiter_guard_errors() -> anyhow::Result<()> {
             accounts: marginfi::accounts::UpdateGroupRateLimiter {
                 marginfi_group: test_f.marginfi_group.key,
                 delegate_flow_admin: test_f.payer(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::UpdateGroupRateLimiter {
@@ -430,6 +439,7 @@ async fn update_group_rate_limiter_guard_errors() -> anyhow::Result<()> {
             accounts: marginfi::accounts::UpdateGroupRateLimiter {
                 marginfi_group: test_f.marginfi_group.key,
                 delegate_flow_admin: test_f.payer(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::UpdateGroupRateLimiter {
@@ -487,6 +497,7 @@ async fn update_group_rate_limiter_out_of_order_slot_and_unauthorized() -> anyho
             accounts: marginfi::accounts::UpdateGroupRateLimiter {
                 marginfi_group: test_f.marginfi_group.key,
                 delegate_flow_admin: test_f.payer(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::UpdateGroupRateLimiter {
@@ -520,6 +531,7 @@ async fn update_group_rate_limiter_out_of_order_slot_and_unauthorized() -> anyho
             accounts: marginfi::accounts::UpdateGroupRateLimiter {
                 marginfi_group: test_f.marginfi_group.key,
                 delegate_flow_admin: test_f.payer(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::UpdateGroupRateLimiter {
@@ -566,6 +578,7 @@ async fn update_group_rate_limiter_out_of_order_slot_and_unauthorized() -> anyho
             accounts: marginfi::accounts::UpdateGroupRateLimiter {
                 marginfi_group: test_f.marginfi_group.key,
                 delegate_flow_admin: unauthorized.pubkey(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::UpdateGroupRateLimiter {

--- a/programs/marginfi/tests/admin_actions/setup_bank.rs
+++ b/programs/marginfi/tests/admin_actions/setup_bank.rs
@@ -75,6 +75,7 @@ fn make_write_bank_metadata_ix(
             bank,
             metadata_admin,
             metadata,
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true)),
         data: marginfi::instruction::WriteBankMetadata {
@@ -702,6 +703,7 @@ async fn configure_bank_to_fixed_oracle() -> anyhow::Result<()> {
             accounts: marginfi::accounts::LendingPoolSetOraclePrice {
                 group: test_f.marginfi_group.key,
                 admin: ctx.payer.pubkey(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
                 bank: bank_f.key,
             }
             .to_account_metas(Some(true)),
@@ -992,6 +994,7 @@ async fn update_fixed_bank_price() -> anyhow::Result<()> {
             accounts: marginfi::accounts::LendingPoolSetOraclePrice {
                 group: test_f.marginfi_group.key,
                 admin: ctx.payer.pubkey(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
                 bank: bank_f.key,
             }
             .to_account_metas(Some(true)),

--- a/programs/marginfi/tests/user_actions/flash_loan.rs
+++ b/programs/marginfi/tests/user_actions/flash_loan.rs
@@ -586,6 +586,7 @@ fn create_handle_bankruptcy_cpi_metas(
         AccountMeta::new(accounts.insurance_vault, false),
         AccountMeta::new_readonly(accounts.insurance_vault_authority, false),
         AccountMeta::new_readonly(accounts.token_program, false),
+        AccountMeta::new_readonly(accounts.marginfi_program, false),
     ]
 }
 

--- a/programs/marginfi/tests/user_actions/flash_loan.rs
+++ b/programs/marginfi/tests/user_actions/flash_loan.rs
@@ -8,6 +8,7 @@ use marginfi_type_crate::constants::{
 };
 use pretty_assertions::assert_eq;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
+use solana_instructions_sysvar;
 use solana_program_test::*;
 use solana_sdk::signature::Keypair;
 use solana_sdk::{signer::Signer, transaction::Transaction};
@@ -585,7 +586,7 @@ fn create_handle_bankruptcy_cpi_metas(
         AccountMeta::new(accounts.insurance_vault, false),
         AccountMeta::new_readonly(accounts.insurance_vault_authority, false),
         AccountMeta::new_readonly(accounts.token_program, false),
-        AccountMeta::new_readonly(accounts.marginfi_program, false),
+        AccountMeta::new_readonly(accounts.instruction_sysvar, false),
     ]
 }
 
@@ -641,13 +642,17 @@ async fn flashloan_fail_bankruptcy_during_flashloan() -> anyhow::Result<()> {
         insurance_vault,
         insurance_vault_authority,
         token_program: anchor_spl::token::ID,
-        marginfi_program: marginfi::ID,
+        instruction_sysvar: solana_instructions_sysvar::id(),
     };
 
     let mut metas = create_handle_bankruptcy_cpi_metas(&cpi_accounts);
-    let remaining = borrower_mfi_account_f
+    let mut remaining = borrower_mfi_account_f
         .load_observation_account_metas(vec![], vec![])
         .await;
+    remaining.insert(
+        0,
+        AccountMeta::new_readonly(solana_instructions_sysvar::id(), false),
+    );
 
     metas.extend_from_slice(&remaining);
 

--- a/programs/marginfi/tests/user_actions/flash_loan.rs
+++ b/programs/marginfi/tests/user_actions/flash_loan.rs
@@ -586,7 +586,6 @@ fn create_handle_bankruptcy_cpi_metas(
         AccountMeta::new(accounts.insurance_vault, false),
         AccountMeta::new_readonly(accounts.insurance_vault_authority, false),
         AccountMeta::new_readonly(accounts.token_program, false),
-        AccountMeta::new_readonly(accounts.instruction_sysvar, false),
     ]
 }
 
@@ -642,7 +641,7 @@ async fn flashloan_fail_bankruptcy_during_flashloan() -> anyhow::Result<()> {
         insurance_vault,
         insurance_vault_authority,
         token_program: anchor_spl::token::ID,
-        instruction_sysvar: solana_instructions_sysvar::id(),
+        marginfi_program: marginfi::ID,
     };
 
     let mut metas = create_handle_bankruptcy_cpi_metas(&cpi_accounts);

--- a/programs/marginfi/tests/user_actions/flash_loan.rs
+++ b/programs/marginfi/tests/user_actions/flash_loan.rs
@@ -8,7 +8,6 @@ use marginfi_type_crate::constants::{
 };
 use pretty_assertions::assert_eq;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
-use solana_instructions_sysvar;
 use solana_program_test::*;
 use solana_sdk::signature::Keypair;
 use solana_sdk::{signer::Signer, transaction::Transaction};

--- a/programs/marginfi/tests/user_actions/kamino.rs
+++ b/programs/marginfi/tests/user_actions/kamino.rs
@@ -161,6 +161,7 @@ async fn kamino_withdraw_records_underlying_on_bank_rate_limiter() -> anyhow::Re
             group: setup.test_f.marginfi_group.key,
             admin: admin.pubkey(),
             bank: setup.bank_f.key,
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true)),
         data: marginfi::instruction::ConfigureBankRateLimits {

--- a/programs/marginfi/tests/user_actions/liquidate_receiver.rs
+++ b/programs/marginfi/tests/user_actions/liquidate_receiver.rs
@@ -721,6 +721,7 @@ async fn liquidate_receiver_repay_without_oracles_should_succeed() -> anyhow::Re
             accounts: marginfi::accounts::ConfigureGroupRateLimits {
                 marginfi_group: test_f.marginfi_group.key,
                 admin: ctx.payer.pubkey(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::ConfigureGroupRateLimits {

--- a/programs/marginfi/tests/user_actions/liquidate_receiver_cpi.rs
+++ b/programs/marginfi/tests/user_actions/liquidate_receiver_cpi.rs
@@ -321,9 +321,13 @@ async fn handle_bankruptcy_via_cpi_fails() -> anyhow::Result<()> {
     };
 
     let mut metas = create_handle_bankruptcy_cpi_metas(&cpi_accounts);
-    let remaining = attacker_acc
+    let mut remaining = attacker_acc
         .load_observation_account_metas(vec![], vec![])
         .await;
+    remaining.insert(
+        0,
+        AccountMeta::new_readonly(solana_instructions_sysvar::id(), false),
+    );
 
     metas.extend_from_slice(&remaining);
 

--- a/programs/mocks/src/instructions/handle_bankruptcy.rs
+++ b/programs/mocks/src/instructions/handle_bankruptcy.rs
@@ -74,6 +74,7 @@ impl HandleBankruptcyViaCpi<'_> {
             ctx.accounts.insurance_vault.to_account_info(),
             ctx.accounts.insurance_vault_authority.to_account_info(),
             ctx.accounts.token_program.to_account_info(),
+            ctx.accounts.marginfi_program.to_account_info(),
         ];
 
         infos.extend_from_slice(ctx.remaining_accounts);

--- a/test-utils/src/bank.rs
+++ b/test-utils/src/bank.rs
@@ -103,6 +103,7 @@ impl BankFixture {
             group: self.load().await.group,
             admin: self.ctx.borrow().payer.pubkey(),
             bank: self.key,
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
 
@@ -122,6 +123,7 @@ impl BankFixture {
                 group: self.load().await.group,
                 admin: self.ctx.borrow().payer.pubkey(),
                 bank: self.key,
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true));
 
@@ -227,6 +229,7 @@ impl BankFixture {
             fee_vault: bank.fee_vault,
             fee_vault_authority,
             dst_token_account: receiving_account.key,
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
         if self.mint.token_program == anchor_spl::token_2022::ID {
@@ -309,6 +312,7 @@ impl BankFixture {
             bank: self.key,
             admin: signer_pk,
             destination_account: destination_account.key,
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
         if self.mint.token_program == anchor_spl::token_2022::ID {
@@ -354,6 +358,7 @@ impl BankFixture {
             insurance_vault: bank.insurance_vault,
             insurance_vault_authority,
             dst_token_account: receiving_account.key,
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
         if self.mint.token_program == anchor_spl::token_2022::ID {
@@ -443,6 +448,7 @@ impl BankFixture {
             group: bank.group,
             authority,
             bank: self.key,
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
         Instruction {

--- a/test-utils/src/marginfi_account.rs
+++ b/test-utils/src/marginfi_account.rs
@@ -344,6 +344,7 @@ impl MarginfiAccountFixture {
                 group: marginfi_account.group,
                 marginfi_account: self.key,
                 admin: self.ctx.borrow().payer.pubkey(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::MarginfiAccountSetFreeze { frozen }.data(),
@@ -2334,6 +2335,7 @@ impl MarginfiAccountFixture {
                 liquidation_record,
                 group: marginfi_account.group,
                 risk_admin,
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::EndDeleverage {}.data(),

--- a/test-utils/src/marginfi_group.rs
+++ b/test-utils/src/marginfi_group.rs
@@ -83,6 +83,7 @@ impl MarginfiGroupFixture {
                     admin,
                     fee_state: fee_state_key,
                     system_program: system_program::id(),
+                    instruction_sysvar: solana_sdk::sysvar::instructions::ID,
                 }
                 .to_account_metas(Some(true)),
                 data: marginfi::instruction::MarginfiGroupInitialize {}.data(),
@@ -93,6 +94,7 @@ impl MarginfiGroupFixture {
                 accounts: marginfi::accounts::MarginfiGroupConfigure {
                     marginfi_group: group_key.pubkey(),
                     admin,
+                    instruction_sysvar: solana_sdk::sysvar::instructions::ID,
                 }
                 .to_account_metas(Some(true)),
                 data: MarginfiGroupConfigure {
@@ -198,6 +200,7 @@ impl MarginfiGroupFixture {
                     fee_payer: ctx.payer.pubkey(),
                     staked_settings: staked_settings_key,
                     system_program: system_program::id(),
+                    instruction_sysvar: solana_sdk::sysvar::instructions::ID,
                 }
                 .to_account_metas(Some(true)),
                 data: InitStakedSettings { settings }.data(),
@@ -259,6 +262,7 @@ impl MarginfiGroupFixture {
             fee_vault: bank_fixture.get_vault(BankVaultType::Fee).0,
             token_program: bank_asset_mint_fixture.token_program,
             system_program: system_program::id(),
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
 
@@ -363,6 +367,7 @@ impl MarginfiGroupFixture {
             fee_vault: bank_fixture.get_vault(BankVaultType::Fee).0,
             token_program: bank_fixture.get_token_program(),
             system_program: system_program::id(),
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
 
@@ -419,6 +424,7 @@ impl MarginfiGroupFixture {
             bank: bank.key,
             group: self.key,
             admin: self.ctx.borrow().payer.pubkey(),
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
 
@@ -440,6 +446,7 @@ impl MarginfiGroupFixture {
             bank: bank.key,
             group: self.key,
             admin: self.ctx.borrow().payer.pubkey(),
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
 
@@ -464,6 +471,7 @@ impl MarginfiGroupFixture {
             group: self.key,
             admin: self.ctx.borrow().payer.pubkey(),
             bank: bank.key,
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
 
@@ -488,6 +496,7 @@ impl MarginfiGroupFixture {
             signer: self.ctx.borrow().payer.pubkey(),
             bank: bank.key,
             same_asset_emode_registry: self.same_asset_emode_registry,
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
 
@@ -504,6 +513,7 @@ impl MarginfiGroupFixture {
             signer: self.ctx.borrow().payer.pubkey(),
             same_asset_emode_registry: self.same_asset_emode_registry,
             system_program: system_program::id(),
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
 
@@ -598,6 +608,7 @@ impl MarginfiGroupFixture {
             group: self.key,
             delegate_curve_admin: self.ctx.borrow().payer.pubkey(),
             bank: bank.key,
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
 
@@ -644,6 +655,7 @@ impl MarginfiGroupFixture {
             group: self.key,
             delegate_limit_admin: self.ctx.borrow().payer.pubkey(),
             bank: bank.key,
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
 
@@ -891,6 +903,7 @@ impl MarginfiGroupFixture {
             bank: bank.key,
             group: self.key,
             emode_admin: self.ctx.borrow().payer.pubkey(),
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
 
@@ -936,6 +949,7 @@ impl MarginfiGroupFixture {
             signer,
             copy_from_bank,
             copy_to_bank,
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
 
@@ -1136,6 +1150,7 @@ impl MarginfiGroupFixture {
             accounts: marginfi::accounts::MarginfiGroupConfigure {
                 marginfi_group: self.key,
                 admin: self.ctx.borrow().payer.pubkey(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: MarginfiGroupConfigure {
@@ -1215,6 +1230,7 @@ impl MarginfiGroupFixture {
             accounts: marginfi::accounts::MarginfiGroupConfigure {
                 marginfi_group: self.key,
                 admin: self.ctx.borrow().payer.pubkey(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: MarginfiGroupConfigure {
@@ -1259,6 +1275,7 @@ impl MarginfiGroupFixture {
             accounts: marginfi::accounts::ConfigureDeleverageWithdrawalLimit {
                 marginfi_group: self.key,
                 admin: self.ctx.borrow().payer.pubkey(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: ConfigureDeleverageWithdrawalLimit { limit }.data(),
@@ -1292,6 +1309,7 @@ impl MarginfiGroupFixture {
             accounts: marginfi::accounts::UpdateDeleverageWithdrawals {
                 marginfi_group: self.key,
                 delegate_flow_admin: self.ctx.borrow().payer.pubkey(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: UpdateDeleverageWithdrawals {
@@ -1386,6 +1404,7 @@ impl MarginfiGroupFixture {
             insurance_vault: bank.get_vault(BankVaultType::Insurance).0,
             insurance_vault_authority: bank.get_vault_authority(BankVaultType::Insurance).0,
             token_program: bank.get_token_program(),
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
         if bank.mint.token_program == anchor_spl::token_2022::ID {
@@ -1462,6 +1481,7 @@ impl MarginfiGroupFixture {
             liquidity_vault_authority: bank.get_vault_authority(BankVaultType::Liquidity).0,
             liquidity_vault: bank.get_vault(BankVaultType::Liquidity).0,
             token_program: bank.get_token_program(),
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
         if bank.mint.token_program == anchor_spl::token_2022::ID {
@@ -1540,6 +1560,7 @@ impl MarginfiGroupFixture {
             admin_token_account,
             liquidity_vault: bank.get_vault(BankVaultType::Liquidity).0,
             token_program: bank.get_token_program(),
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         }
         .to_account_metas(Some(true));
         if bank.mint.token_program == anchor_spl::token_2022::ID {
@@ -1713,6 +1734,7 @@ impl MarginfiGroupFixture {
             accounts: marginfi::accounts::PanicPause {
                 pause_authority: pause_authority.pubkey(),
                 fee_state: self.fee_state,
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: PanicPause {}.data(),
@@ -1752,6 +1774,7 @@ impl MarginfiGroupFixture {
             accounts: marginfi::accounts::PanicUnpause {
                 global_fee_admin: pause_authority.pubkey(),
                 fee_state: self.fee_state,
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: PanicUnpause {}.data(),
@@ -1786,6 +1809,7 @@ impl MarginfiGroupFixture {
             accounts: marginfi::accounts::EditFeeState {
                 global_fee_admin: self.ctx.borrow().payer.pubkey(),
                 fee_state: self.fee_state,
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: EditGlobalFeeState {
@@ -1850,6 +1874,7 @@ impl MarginfiGroupFixture {
                 group: self.key,
                 admin: self.ctx.borrow().payer.pubkey(),
                 staked_settings: self.staked_settings,
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: DisableStakedOracles {}.data(),
@@ -1876,6 +1901,7 @@ impl MarginfiGroupFixture {
                 group: self.key,
                 admin: self.ctx.borrow().payer.pubkey(),
                 staked_settings: self.staked_settings,
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: EnableStakedOracleOnramp {}.data(),

--- a/test-utils/src/marginfi_group.rs
+++ b/test-utils/src/marginfi_group.rs
@@ -742,6 +742,7 @@ impl MarginfiGroupFixture {
             accounts: marginfi::accounts::EditFeeStatePremium {
                 global_fee_admin: signer.pubkey(),
                 fee_state: self.fee_state,
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: EditFeeStatePremium { premium_wallet }.data(),
@@ -780,6 +781,7 @@ impl MarginfiGroupFixture {
             accounts: marginfi::accounts::LendingPoolConfigureGroupPremium {
                 group: self.key,
                 emode_admin: signer.pubkey(),
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: LendingPoolConfigureGroupPremium {
@@ -827,6 +829,7 @@ impl MarginfiGroupFixture {
                 group: self.key,
                 emode_admin: signer.pubkey(),
                 bank: bank.key,
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: LendingPoolConfigureBankPremium {

--- a/test-utils/src/test.rs
+++ b/test-utils/src/test.rs
@@ -1426,6 +1426,7 @@ impl TestFixture {
             fee_vault: derive_bank_vault(&bank_key, BankVaultType::Fee, &marginfi::ID).0,
             token_program: reserve_mint.token_program,
             system_program: system_program::ID,
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         };
         let mut add_bank_ix = Instruction {
             program_id: marginfi::ID,
@@ -1664,6 +1665,7 @@ impl TestFixture {
             fee_vault: derive_bank_vault(&bank_key, BankVaultType::Fee, &marginfi::ID).0,
             token_program: spl_token::ID,
             system_program: system_program::ID,
+            instruction_sysvar: solana_sdk::sysvar::instructions::ID,
         };
         let mut add_bank_ix = Instruction {
             program_id: marginfi::ID,
@@ -2134,6 +2136,7 @@ impl TestFixture {
                 integration_acc_2: derive_juplend_f_token_vault(&marginfi::ID, &bank_key).0,
                 token_program,
                 system_program: system_program::ID,
+                instruction_sysvar: solana_sdk::sysvar::instructions::ID,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::LendingPoolAddBankJuplend {


### PR DESCRIPTION
#639 

credits to @ashleychandy for creating this PR

## Description

Prevent durable nonce transactions from being used with privileged/admin instructions to reduce attack surface. User-facing instructions such as deposit, withdraw, borrow, and repay continue to allow durable nonce transactions.

## Changes

- Added `check_no_durable_nonce` helper in `ix_utils`.
- Added `DurableNonceNotAllowed` error.
- Added the Instructions sysvar account to protected admin instructions.
- Invoked durable nonce validation before executing admin operations.
- Applied the restriction across admin/configuration, bank management, fee management, risk admin, and protocol administration instructions.

Fixes #637 