### PR TITLE
Same asset auto-rebalance fixes

### DIFF
--- a/programs/marginfi/src/errors.rs
+++ b/programs/marginfi/src/errors.rs
@@ -511,6 +511,8 @@ pub enum MarginfiError {
     RebalanceStaleExecutionSeq, // 6716
     #[msg("Rebalance allowlist contains a bank the account owes into")]
     RebalanceAllowlistLiability, // 6717
+    #[msg("Rebalance moves use a bank as both a source and a destination")]
+    RebalanceBankSourceAndDestination, // 6718
     // ************** END AUTO-REBALANCE ERRORS
     // ************** BEGIN SCOPE ERRORS (starting at 6800)
     #[msg("Scope oracle account is not owned by the Scope program or is malformed")]
@@ -788,6 +790,7 @@ impl From<u32> for MarginfiError {
             6715 => MarginfiError::RebalanceNotBestVenue,
             6716 => MarginfiError::RebalanceStaleExecutionSeq,
             6717 => MarginfiError::RebalanceAllowlistLiability,
+            6718 => MarginfiError::RebalanceBankSourceAndDestination,
 
             // Premium-specific errors (starting at 6610)
             6610 => MarginfiError::PremiumEntryInvalid,

--- a/programs/marginfi/src/instructions/marginfi_account/admin_close.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/admin_close.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::clock::Clock;
+use marginfi_type_crate::constants::REBALANCE_FEE_POOL_SEED;
 use marginfi_type_crate::types::{
     MarginfiAccount, MarginfiGroup, ACCOUNT_IN_DELEVERAGE, ACCOUNT_IN_ORDER_EXECUTION,
     SECONDS_PER_DAY,
@@ -38,6 +39,12 @@ pub fn admin_close_account(ctx: Context<AdminCloseAccount>) -> MarginfiResult {
         "Account cannot be closed"
     );
 
+    check!(
+        ctx.accounts.rebalance_fee_pool.lamports() == 0,
+        MarginfiError::IllegalAction,
+        "Withdraw rebalance fee pool before closing account"
+    );
+
     emit!(AdminCloseAccountEvent {
         header: AccountEventHeader {
             signer: None,
@@ -69,4 +76,12 @@ pub struct AdminCloseAccount<'info> {
             @ MarginfiError::InvalidGlobalFeeWallet
     )]
     pub global_fee_wallet: UncheckedAccount<'info>,
+
+    /// CHECK: the account's rebalance fee pool PDA; validated by seeds. Must be empty (drained via
+    /// `withdraw_rebalance_fee_pool`) before close so its lamports are not orphaned.
+    #[account(
+        seeds = [REBALANCE_FEE_POOL_SEED.as_bytes(), marginfi_account.key().as_ref()],
+        bump,
+    )]
+    pub rebalance_fee_pool: SystemAccount<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_account/rebalance.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/rebalance.rs
@@ -5,13 +5,15 @@
 //! consumed on execution; it persists until cancelled.
 //!
 //! On-chain guarantees: every referenced bank holds the order's mint and is in the allowed set; each
-//! declared move goes from a lower-rate bank to one beating it by `min_improvement` (pre-move) and
-//! not inverted after the move's own market impact (post-move); no move passes over a higher-rate
-//! referenced bank that still has deposit capacity, measured as the tighter of the bank's own limit
-//! and its venue's; the total tokens moved are capped by the order's `amount` budget (uncapped when
-//! the order is unlimited); token principal is conserved per bank up to a small dust tolerance; the
-//! non-referenced balance set is unchanged, neither altered nor added to; the account stays healthy
-//! at the maintenance requirement if it borrows; and a per-order cooldown.
+//! move's destination, priced with every declared deposit into it counted, beats the move's source
+//! by `min_improvement` before the legs run and still does after they land; no other referenced
+//! bank with deposit capacity, measured as the tighter of the bank's own limit and its venue's,
+//! would pay the move's tokens more, counting that bank's own declared inflow; a bank is either a
+//! source or a destination within one execution; the total tokens moved are capped by the order's
+//! `amount` budget (uncapped when the order is unlimited); token principal is conserved per bank
+//! up to a small dust tolerance; the non-referenced balance set is unchanged, neither altered nor
+//! added to; the account stays healthy at the maintenance requirement if it borrows; and a
+//! per-order cooldown.
 //!
 //! Supports native, Kamino, Drift, and JupLend legs; Solend banks are rate-visible but have no move
 //! legs and are rejected up front. Referenced banks arrive as a deduped, indexed stream in the
@@ -53,7 +55,7 @@ use crate::{
         marginfi_group::MarginfiGroupImpl,
         premium::{MarginfiAccountPremiumImpl, PremiumScratch},
         price::OraclePriceFeedAdapter,
-        rate::{self, rate_at, rate_of, RewardsAccounts},
+        rate::{self, rate_at, rate_of, NativeRateModel, RewardsAccounts},
         rebalance::{RebalanceOrderImpl, RebalanceRecordImpl},
     },
     utils::is_integration_asset_tag,
@@ -151,8 +153,8 @@ fn deposit_capacity_of<'info>(
 
 /// A whole-token UI amount as raw native units of the mint, the form venue rate models take. Inverse
 /// of the scaling `underlying_of` applies.
-fn to_native(mint_decimals: u8, amount: WrappedI80F48) -> MarginfiResult<u64> {
-    I80F48::from(amount)
+fn to_native(mint_decimals: u8, amount: I80F48) -> MarginfiResult<u64> {
+    amount
         .checked_mul(EXP_10_I80F48[mint_decimals as usize])
         .ok_or_else(math_error!())?
         .checked_to_num::<u64>()
@@ -789,6 +791,8 @@ pub fn start_rebalance<'info>(
     let mut rates: Vec<I80F48> = Vec::with_capacity(banks.len());
     let mut capacity: Vec<I80F48> = Vec::with_capacity(banks.len());
     let mut ref_banks: Vec<(Pubkey, I80F48)> = Vec::with_capacity(banks.len());
+    // Native banks price from their own curve and totals, captured once here and reused below.
+    let mut models: Vec<Option<NativeRateModel>> = Vec::with_capacity(banks.len());
     for parsed in banks.iter() {
         // `parse_rebalance_banks` rejects duplicates and yields exactly `allowed.len()` banks, so
         // membership here makes the parsed set the allowlist exactly.
@@ -805,13 +809,21 @@ pub fn start_rebalance<'info>(
             bank.config.asset_tag != ASSET_TAG_SOLEND,
             MarginfiError::RebalanceVenueUnsupported
         );
-        let rate = rate_of(
-            &bank,
-            parsed.oracles,
-            parsed.token_reserve,
-            parsed.rewards,
-            &clock,
-        )?;
+        let model = if is_integration_asset_tag(bank.config.asset_tag) {
+            None
+        } else {
+            Some(NativeRateModel::new(&bank)?)
+        };
+        let rate = match &model {
+            Some(model) => model.rate_at(0)?,
+            None => rate_of(
+                &bank,
+                parsed.oracles,
+                parsed.token_reserve,
+                parsed.rewards,
+                &clock,
+            )?,
+        };
         let multiplier = venue_multiplier(&bank, parsed.oracles, &clock)?;
         let pre = bank_underlying(&account, &parsed.key, &bank, multiplier)?;
         rates.push(rate);
@@ -822,59 +834,84 @@ pub fn start_rebalance<'info>(
             &clock,
         )?);
         ref_banks.push((parsed.key, pre));
+        models.push(model);
     }
 
-    // Tokens each bank receives across all declared moves.
+    // Tokens each bank receives across all declared moves. A bank may not be both a source and a
+    // destination, so a destination's post-move supply is its current supply plus this inflow.
     let mut inflow = vec![I80F48::ZERO; banks.len()];
     for m in moves.iter() {
+        check!(
+            !moves.iter().any(|o| o.dst_index == m.src_index),
+            MarginfiError::RebalanceBankSourceAndDestination
+        );
         let d = m.dst_index as usize;
         inflow[d] = inflow[d]
             .checked_add(I80F48::from(m.amount))
             .ok_or_else(math_error!())?;
     }
 
-    // Destination rates are evaluated after the move's own deposit, every candidate at the same amount.
+    // Every referenced bank holds the order's mint, so one decimals value scales all of them.
+    let mint_decimals = banks[0].loader.load()?.mint_decimals;
+    let inflow_native = inflow
+        .iter()
+        .map(|ui| to_native(mint_decimals, *ui))
+        .collect::<MarginfiResult<Vec<u64>>>()?;
+
+    // The supply rate bank `i` would pay after `extra_native` more tokens are deposited into it.
+    let rate_after = |i: usize, extra_native: u64| -> MarginfiResult<I80F48> {
+        match &models[i] {
+            Some(model) => model.rate_at(extra_native),
+            None => {
+                let parsed = &banks[i];
+                rate_at(
+                    &*parsed.loader.load()?,
+                    parsed.oracles,
+                    parsed.token_reserve,
+                    parsed.rewards,
+                    extra_native,
+                    &clock,
+                )
+            }
+        }
+    };
+
+    // Each bank's supply rate with all of its declared inflow deposited. A native bank's rate only
+    // falls as supply grows, so this is also its highest possible rate for any further deposit.
+    let mut landed: Vec<I80F48> = Vec::with_capacity(banks.len());
+    for i in 0..banks.len() {
+        landed.push(if inflow_native[i] == 0 {
+            rates[i]
+        } else {
+            rate_after(i, inflow_native[i])?
+        });
+    }
+
+    // Every other bank is priced with this move's tokens added on top of its own declared inflow:
+    // the rate those tokens would earn there instead of at the destination.
     for m in moves.iter() {
         let d = m.dst_index as usize;
-        let dst = &banks[d];
-        let (amount_native, dst_rate) = {
-            let bank = dst.loader.load()?;
-            let amount_native = to_native(bank.mint_decimals, m.amount)?;
-            let rate = rate_at(
-                &bank,
-                dst.oracles,
-                dst.token_reserve,
-                dst.rewards,
-                amount_native,
-                &clock,
-            )?;
-            (amount_native, rate)
-        };
         // The destination must beat the source, as the source stands today, by the margin.
         check!(
-            dst_rate
+            landed[d]
                 > rates[m.src_index as usize]
                     .checked_add(min_imp)
                     .ok_or_else(math_error!())?,
             MarginfiError::RebalanceNotImproving
         );
-        // Banks this execution has already filled to their deposit capacity are skipped; no other
-        // bank may beat the destination at the same deposit amount.
+        let amount_native = to_native(mint_decimals, I80F48::from(m.amount))?;
+        // Skip banks this execution already fills to capacity, and native banks already at or below
+        // the destination's rate with their own inflow (more deposits only lower a native rate).
         for i in 0..banks.len() {
-            if i == d || inflow[i] >= capacity[i] {
+            if i == d || inflow[i] >= capacity[i] || (models[i].is_some() && landed[i] <= landed[d])
+            {
                 continue;
             }
-            let other = &banks[i];
-            let other_bank = other.loader.load()?;
-            let candidate = rate_at(
-                &other_bank,
-                other.oracles,
-                other.token_reserve,
-                other.rewards,
-                amount_native,
-                &clock,
-            )?;
-            check!(candidate <= dst_rate, MarginfiError::RebalanceNotBestVenue);
+            let extra_native = inflow_native[i]
+                .checked_add(amount_native)
+                .ok_or_else(math_error!())?;
+            let candidate = rate_after(i, extra_native)?;
+            check!(candidate <= landed[d], MarginfiError::RebalanceNotBestVenue);
         }
     }
 
@@ -998,10 +1035,8 @@ pub fn end_rebalance<'info>(ctx: Context<'info, EndRebalance<'info>>) -> Marginf
         // Every referenced bank holds the order's mint, so one decimals value scales all of them.
         let mint_decimals = banks[0].loader.load()?.mint_decimals;
 
-        // Measure every referenced bank once: current supply rate (for the per-move overshoot check),
-        // post-move underlying-token amount (for the token-principal reconciliation), and the yield
-        // index (recorded so settlement can measure realized yield since the move).
-        let mut post_rates: Vec<I80F48> = Vec::with_capacity(banks.len());
+        // Measure every referenced bank once: its post-move underlying-token amount (for
+        // reconciliation) and its yield index (recorded so settlement can measure realized yield).
         let mut post_underlying: Vec<I80F48> = Vec::with_capacity(banks.len());
         let mut yield_indices: Vec<I80F48> = Vec::with_capacity(banks.len());
         // Venues settle in whole accounting tokens, so the widest multiplier is the largest
@@ -1011,13 +1046,6 @@ pub fn end_rebalance<'info>(ctx: Context<'info, EndRebalance<'info>>) -> Marginf
             let bank = parsed.loader.load()?;
             let multiplier = venue_multiplier(&bank, parsed.oracles, &clock)?;
             max_multiplier = max_multiplier.max(multiplier);
-            post_rates.push(rate_of(
-                &bank,
-                parsed.oracles,
-                parsed.token_reserve,
-                parsed.rewards,
-                &clock,
-            )?);
             post_underlying.push(bank_underlying(&account, &parsed.key, &bank, multiplier)?);
             yield_indices.push(yield_index_of(&bank, multiplier)?);
         }
@@ -1025,13 +1053,29 @@ pub fn end_rebalance<'info>(ctx: Context<'info, EndRebalance<'info>>) -> Marginf
         // Every move must not have inverted its rate advantage (the destination still beats the source
         // after the move's own market impact).
         let record = ctx.accounts.rebalance_record.load()?;
+        let mut post_rates = [None; MAX_REBALANCE_BANKS];
         for m in record.active_moves() {
+            let d = m.dst_index as usize;
             // The destination is measured AFTER its own deposit diluted it; the source is the rate it
             // stood at before the move.
+            let post_rate = match post_rates[d] {
+                Some(rate) => rate,
+                None => {
+                    let parsed = &banks[d];
+                    let rate = rate_of(
+                        &*parsed.loader.load()?,
+                        parsed.oracles,
+                        parsed.token_reserve,
+                        parsed.rewards,
+                        &clock,
+                    )?;
+                    post_rates[d] = Some(rate);
+                    rate
+                }
+            };
             let pre_src = I80F48::from(record.pre_rate[m.src_index as usize]);
             check!(
-                post_rates[m.dst_index as usize]
-                    > pre_src.checked_add(min_imp).ok_or_else(math_error!())?,
+                post_rate > pre_src.checked_add(min_imp).ok_or_else(math_error!())?,
                 MarginfiError::RebalanceOvershoot
             );
         }

--- a/programs/marginfi/src/state/interest_rate.rs
+++ b/programs/marginfi/src/state/interest_rate.rs
@@ -5,12 +5,12 @@ use marginfi_type_crate::{
     constants::SECONDS_PER_YEAR,
     types::{
         u32_to_centi, u32_to_milli, InterestRateConfig, InterestRateConfigOpt, MarginfiGroup,
-        RatePoint, INTEREST_CURVE_LEGACY, INTEREST_CURVE_SEVEN_POINT,
+        RatePoint, CURVE_POINTS, INTEREST_CURVE_LEGACY, INTEREST_CURVE_SEVEN_POINT,
     },
 };
 
 use crate::{
-    debug,
+    check, debug,
     errors::MarginfiError,
     math_error,
     prelude::MarginfiResult,
@@ -244,28 +244,15 @@ impl InterestRateCalc {
     /// * Points defined as 1: (0, Y1), 2-6: (X2-6, Y2-6), 7: (100, Y7), where 0 < X2-6 < 100
     #[inline]
     fn interest_rate_multipoint_curve(&self, ur: I80F48) -> Option<I80F48> {
-        let zero_rate: I80F48 = u32_to_milli(self.zero_util_rate);
-        let hundred_rate: I80F48 = u32_to_milli(self.hundred_util_rate);
-
-        // The first point is at (0, zero_rate)
-        let mut prev_util: I80F48 = I80F48::ZERO;
-        let mut prev_rate: I80F48 = zero_rate;
-        // Sanity check: clamp the UR in case we somehow exceeded 100% or went negative
-        let ur: I80F48 = ur.max(I80F48::ZERO).min(I80F48::ONE);
-
-        for point in self.points.iter().filter(|point| point.util() != 0) {
-            let point_util: I80F48 = u32_to_centi(point.util());
-            let point_rate: I80F48 = u32_to_milli(point.rate());
-
-            if ur <= point_util {
-                return Self::lerp(prev_util, prev_rate, point_util, point_rate, ur);
-            }
-
-            prev_util = point_util;
-            prev_rate = point_rate;
-        }
-
-        Self::lerp(prev_util, prev_rate, I80F48::ONE, hundred_rate, ur)
+        multipoint_curve(
+            u32_to_milli(self.zero_util_rate),
+            u32_to_milli(self.hundred_util_rate),
+            self.points
+                .iter()
+                .filter(|point| point.util() != 0)
+                .map(|point| (u32_to_centi(point.util()), u32_to_milli(point.rate()))),
+            ur,
+        )
     }
 
     /// Given two points (start_x, start_y) and (end_x, end_y), and a target x between start_x and
@@ -322,6 +309,75 @@ impl InterestRateCalc {
             protocol_fee_rate,
             protocol_fee_fixed,
         }
+    }
+}
+
+/// The rate at utilization `ur` on the piecewise linear curve through (0, `zero_rate`), `points` in
+/// ascending utilization, and (100%, `hundred_rate`).
+#[inline]
+fn multipoint_curve(
+    zero_rate: I80F48,
+    hundred_rate: I80F48,
+    points: impl Iterator<Item = (I80F48, I80F48)>,
+    ur: I80F48,
+) -> Option<I80F48> {
+    let mut prev_util: I80F48 = I80F48::ZERO;
+    let mut prev_rate: I80F48 = zero_rate;
+    // Sanity check: clamp the UR in case we somehow exceeded 100% or went negative
+    let ur: I80F48 = ur.max(I80F48::ZERO).min(I80F48::ONE);
+
+    for (point_util, point_rate) in points {
+        if ur <= point_util {
+            return InterestRateCalc::lerp(prev_util, prev_rate, point_util, point_rate, ur);
+        }
+        prev_util = point_util;
+        prev_rate = point_rate;
+    }
+
+    InterestRateCalc::lerp(prev_util, prev_rate, I80F48::ONE, hundred_rate, ur)
+}
+
+/// A bank's seven-point interest curve with its points converted to I80F48 once, for repeated
+/// lookups at different utilizations.
+pub struct LendingCurve {
+    zero_rate: I80F48,
+    hundred_rate: I80F48,
+    points: [(I80F48, I80F48); CURVE_POINTS],
+    used: usize,
+}
+
+impl LendingCurve {
+    pub fn new(config: &InterestRateConfig) -> MarginfiResult<Self> {
+        check!(
+            config.curve_type == INTEREST_CURVE_SEVEN_POINT,
+            MarginfiError::InvalidConfig
+        );
+        let mut points = [(I80F48::ZERO, I80F48::ZERO); CURVE_POINTS];
+        let mut used = 0;
+        for point in config.points.iter().filter(|point| point.util() != 0) {
+            points[used] = (u32_to_centi(point.util()), u32_to_milli(point.rate()));
+            used += 1;
+        }
+        Ok(Self {
+            zero_rate: u32_to_milli(config.zero_util_rate),
+            hundred_rate: u32_to_milli(config.hundred_util_rate),
+            points,
+            used,
+        })
+    }
+
+    /// The lending rate at `utilization`: the curve's base rate times the utilization. Fees do not
+    /// enter it.
+    pub fn lending_rate(&self, utilization: I80F48) -> MarginfiResult<I80F48> {
+        multipoint_curve(
+            self.zero_rate,
+            self.hundred_rate,
+            self.points[..self.used].iter().copied(),
+            utilization,
+        )
+        .and_then(|base_rate| base_rate.checked_mul(utilization))
+        .ok_or_else(math_error!())
+        .map_err(Into::into)
     }
 }
 
@@ -623,6 +679,35 @@ mod tests {
             .calc_interest_rate(I80F48!(0.4))
             .expect("computed rate");
         assert_eq_with_tolerance!(base_rate_apr, I80F48!(0.125), I80F48!(0.0001));
+    }
+
+    /// The precomputed curve returns exactly the lending rate the accrual calculator computes.
+    #[test]
+    fn lending_curve_matches_calc_interest_rate() {
+        let calc = sample_multipoint_calc();
+        let curve = LendingCurve::new(&InterestRateConfig {
+            zero_util_rate: apr_to_u32(0.05),
+            hundred_util_rate: apr_to_u32(0.40),
+            points: make_points(&[
+                RatePoint::new(util_to_u32(0.20), apr_to_u32(0.10)),
+                RatePoint::new(util_to_u32(0.60), apr_to_u32(0.15)),
+            ]),
+            curve_type: INTEREST_CURVE_SEVEN_POINT,
+            ..Default::default()
+        })
+        .expect("seven-point curve");
+        for util in [
+            I80F48::ZERO,
+            I80F48!(0.2),
+            I80F48!(0.4),
+            I80F48!(0.9),
+            I80F48::ONE,
+        ] {
+            assert_eq!(
+                curve.lending_rate(util).unwrap(),
+                calc.calc_interest_rate(util).unwrap().lending_rate_apr
+            );
+        }
     }
 
     /// The auto-rebalance order compares integration supply APRs against native bank rates, so they

--- a/programs/marginfi/src/state/rate.rs
+++ b/programs/marginfi/src/state/rate.rs
@@ -6,8 +6,8 @@
 //! reads and unit-tested there. This module only dispatches by `asset_tag`, loads/staleness-checks
 //! the rate-bearing account, and maps the pure `Option` result to a marginfi error:
 //!
-//! - Native marginfi banks: read the cached `lending_rate` (net by construction; fees fall on
-//!   borrowers). Must be fresh (crank `accrue_bank_interest`/`update_bank_cache` first).
+//! - Native marginfi banks: the bank's own interest curve at its utilization after the deposit (net
+//!   by construction; fees fall on borrowers). The caller accrues the bank first.
 //! - Kamino: `borrow_apr(util) * util * (1 - protocol_take_rate)`, rescaled from klend's slot-year
 //!   to a wall-clock year at measured chain pacing.
 //! - Drift: `borrow_apr(util) * util * (1 - insurance_fund.total_factor)`.
@@ -19,6 +19,8 @@
 //! (`refresh_reserve` / `update_spot_market_cumulative_interest` / JupLend liquidity-program
 //! `update_exchange_price`, which refreshes the `TokenReserve` the supply rate reads).
 
+use crate::state::bank::BankImpl;
+use crate::state::interest_rate::LendingCurve;
 use crate::state::price::{
     load_drift_spot_market, load_juplend_lending, load_kamino_reserve, load_solend_reserve,
 };
@@ -33,7 +35,7 @@ use marginfi_type_crate::constants::{
     ASSET_TAG_DEFAULT, ASSET_TAG_DRIFT, ASSET_TAG_JUPLEND, ASSET_TAG_KAMINO, ASSET_TAG_SOL,
     ASSET_TAG_SOLEND, ASSET_TAG_STAKED,
 };
-use marginfi_type_crate::types::{u32_to_milli, Bank, BankConfig};
+use marginfi_type_crate::types::{Bank, BankConfig};
 
 /// Accounts a venue needs beyond its rate-bearing account to price its reward emissions, each bound
 /// to the bank's own venue state. Callers that need only the base rate pass the default.
@@ -47,11 +49,12 @@ pub struct RewardsAccounts<'info> {
     pub ftoken_mint: Option<&'info AccountInfo<'info>>,
 }
 
-/// Supply APR (I80F48, 1.0 == 100%) for `bank`, dispatched on `asset_tag` (the canonical integration
-/// identifier, consistent with the `is_*_asset_tag` checks used across deposit/withdraw). `venue` is
-/// the rate-bearing account (`None` for native, which prices from the bank cache); `token_reserve`
-/// is JupLend's `TokenReserve` (`None` otherwise). Unknown tags fail rather than default to
-/// native. The caller refreshes the venue this slot and locates it (see `rate_of`).
+/// Supply APR (I80F48, 1.0 == 100%) for `bank` after `extra_native` more tokens are supplied,
+/// dispatched on `asset_tag` (the canonical integration identifier, consistent with the
+/// `is_*_asset_tag` checks used across deposit/withdraw). `venue` is the rate-bearing account
+/// (`None` for native, which prices from its own totals); `token_reserve` is JupLend's
+/// `TokenReserve` (`None` otherwise). Unknown tags fail rather than default to native. The caller
+/// refreshes the venue this slot and locates it (see `rate_of`).
 pub fn current_supply_apr<'info>(
     bank: &Bank,
     venue: Option<&'info AccountInfo<'info>>,
@@ -62,8 +65,7 @@ pub fn current_supply_apr<'info>(
 ) -> MarginfiResult<I80F48> {
     let tag = bank.config.asset_tag;
     if matches!(tag, ASSET_TAG_DEFAULT | ASSET_TAG_SOL | ASSET_TAG_STAKED) {
-        // Native banks price from the stored cache, so `extra_native` does not change the rate.
-        return Ok(u32_to_milli(bank.cache.lending_rate));
+        return NativeRateModel::new(bank)?.rate_at(extra_native);
     }
     let venue = venue.ok_or(MarginfiError::WrongNumberOfOracleAccounts)?;
     match tag {
@@ -79,6 +81,41 @@ pub fn current_supply_apr<'info>(
             clock,
         ),
         _ => err!(MarginfiError::InvalidOracleSetup),
+    }
+}
+
+/// A native bank's interest curve and current totals, captured once after accrual so the bank can
+/// be priced at any deposit size without re-reading it.
+pub struct NativeRateModel {
+    curve: LendingCurve,
+    assets: I80F48,
+    liabilities: I80F48,
+}
+
+impl NativeRateModel {
+    pub fn new(bank: &Bank) -> MarginfiResult<Self> {
+        Ok(Self {
+            curve: LendingCurve::new(&bank.config.interest_rate_config)?,
+            assets: bank.get_asset_amount(bank.total_asset_shares.into())?,
+            liabilities: bank.get_liability_amount(bank.total_liability_shares.into())?,
+        })
+    }
+
+    /// The lending rate after `extra_native` more tokens are deposited. Zero when the bank has no
+    /// deposits or no borrows, matching `update_bank_cache`.
+    pub fn rate_at(&self, extra_native: u64) -> MarginfiResult<I80F48> {
+        let assets = self
+            .assets
+            .checked_add(I80F48::from_num(extra_native))
+            .ok_or_else(math_error!())?;
+        if assets == I80F48::ZERO || self.liabilities == I80F48::ZERO {
+            return Ok(I80F48::ZERO);
+        }
+        let utilization = self
+            .liabilities
+            .checked_div(assets)
+            .ok_or_else(math_error!())?;
+        self.curve.lending_rate(utilization)
     }
 }
 
@@ -365,13 +402,16 @@ fn juplend_supply_apr<'info>(
 /// percentage.
 #[cfg(test)]
 mod unit_consistency {
+    use bytemuck::Zeroable;
     use drift_mocks::state::drift_deposit_rate_from_parts;
     use juplend_mocks::state::juplend_supply_rate_from_parts;
     use kamino_mocks::state::{kamino_supply_apr_from_parts, CurvePoint, KLEND_SLOTS_PER_SECOND};
-    use marginfi_type_crate::types::{milli_to_u32, u32_to_milli};
+    use marginfi_type_crate::types::{
+        make_points, milli_to_u32, u32_to_milli, InterestRateConfig, INTEREST_CURVE_SEVEN_POINT,
+    };
     use solend_mocks::state::solend_supply_rate_from_parts;
 
-    use super::I80F48;
+    use super::{Bank, NativeRateModel, I80F48};
 
     /// The net supply rate each venue reports for `target_bps` (e.g. `1_000` == 10%), built from an
     /// equivalent per-venue config. Returned as `(native, kamino, drift, solend, juplend)`.
@@ -379,8 +419,20 @@ mod unit_consistency {
         // The target percentage as an I80F48 fraction (1.0 == 100%).
         let pct = I80F48::from_num(target_bps) / I80F48::from_num(10_000u32);
 
-        // Native: the bank cache stores the lending rate as a u32 on a 0..1000% scale.
-        let native = u32_to_milli(milli_to_u32(pct));
+        // Native: a curve flat at `pct`, with the bank fully utilized.
+        let mut bank = Bank::zeroed();
+        bank.config.interest_rate_config = InterestRateConfig {
+            zero_util_rate: milli_to_u32(pct),
+            hundred_util_rate: milli_to_u32(pct),
+            points: make_points(&[]),
+            curve_type: INTEREST_CURVE_SEVEN_POINT,
+            ..Default::default()
+        };
+        bank.asset_share_value = I80F48::ONE.into();
+        bank.liability_share_value = I80F48::ONE.into();
+        bank.total_asset_shares = I80F48::from_num(1_000).into();
+        bank.total_liability_shares = I80F48::from_num(1_000).into();
+        let native = NativeRateModel::new(&bank).unwrap().rate_at(0).unwrap();
 
         // Kamino: a flat borrow curve at `target_bps`, evaluated at 100% utilization with no cut,
         // priced at klend's own pacing.
@@ -458,11 +510,53 @@ mod unit_consistency {
             assert_eq!(solend, kamino, "solend != kamino at {target_bps}bps");
             assert_eq!(juplend, kamino, "juplend != kamino at {target_bps}bps");
 
-            // Native stores its rate as a u32 on a 0..1000% scale. Its exact value is that same
-            // quantization round-trip, so assert against the stored-value round-trip, not the input.
+            // Native curve rates are stored as u32 on a 0..1000% scale, so the exact value is that
+            // quantization round-trip; assert against it, not the input.
             let native_quantized = u32_to_milli(milli_to_u32(expected));
             assert_eq!(native, native_quantized, "native at {target_bps}bps");
         }
+    }
+}
+
+/// A native bank is priced on its own curve at the utilization it would have after the deposit.
+#[cfg(test)]
+mod native_dilution {
+    use bytemuck::Zeroable;
+    use marginfi_type_crate::types::{
+        make_points, milli_to_u32, u32_to_milli, InterestRateConfig, INTEREST_CURVE_SEVEN_POINT,
+    };
+
+    use super::{Bank, NativeRateModel, I80F48};
+
+    #[test]
+    fn the_rate_dilutes_with_the_incoming_deposit() {
+        // A linear curve from 0 to `one`, so the lending rate is `one * util^2`.
+        let one = u32_to_milli(milli_to_u32(I80F48::ONE));
+        let mut bank = Bank::zeroed();
+        bank.config.interest_rate_config = InterestRateConfig {
+            hundred_util_rate: milli_to_u32(I80F48::ONE),
+            points: make_points(&[]),
+            curve_type: INTEREST_CURVE_SEVEN_POINT,
+            ..Default::default()
+        };
+        bank.asset_share_value = I80F48::ONE.into();
+        bank.liability_share_value = I80F48::ONE.into();
+        bank.total_asset_shares = I80F48::from_num(1_000).into();
+        bank.total_liability_shares = I80F48::from_num(500).into();
+
+        // Half utilized now; a deposit equal to its current supply leaves it a quarter utilized.
+        let model = NativeRateModel::new(&bank).unwrap();
+        assert_eq!(model.rate_at(0).unwrap(), one * I80F48::from_num(0.25));
+        assert_eq!(
+            model.rate_at(1_000).unwrap(),
+            one * I80F48::from_num(0.0625)
+        );
+
+        bank.total_liability_shares = I80F48::ZERO.into();
+        assert_eq!(
+            NativeRateModel::new(&bank).unwrap().rate_at(1_000).unwrap(),
+            I80F48::ZERO
+        );
     }
 }
 

--- a/programs/marginfi/tests/user_actions/indexer_flags.rs
+++ b/programs/marginfi/tests/user_actions/indexer_flags.rs
@@ -2,7 +2,7 @@ use fixtures::{assert_custom_error, marginfi_account::MarginfiAccountFixture, pr
 use marginfi::errors::MarginfiError;
 use pretty_assertions::assert_eq;
 use solana_program_test::*;
-use solana_sdk::{clock::Clock, signature::Keypair, signer::Signer};
+use solana_sdk::{clock::Clock, signature::Keypair, signer::Signer, transaction::Transaction};
 
 #[tokio::test]
 async fn indexer_flags_new_account_defaults() -> anyhow::Result<()> {
@@ -377,6 +377,44 @@ async fn admin_close_account_fails_with_active_balances() -> anyhow::Result<()> 
     account.indexer_flags.was_active_30d = 0;
     account.indexer_flags.was_active_60d = 0;
     user_f.set_account(&account).await?;
+
+    let global_fee_wallet = test_f.marginfi_group.fee_wallet;
+    let res = user_f.try_admin_close_account(global_fee_wallet).await;
+    assert_custom_error!(res.unwrap_err(), MarginfiError::IllegalAction);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn admin_close_account_fails_with_funded_fee_pool() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(None).await;
+    let authority = Keypair::new();
+
+    let user_f = MarginfiAccountFixture::new_with_authority(
+        test_f.context.clone(),
+        &test_f.marginfi_group.key,
+        &authority,
+    )
+    .await;
+
+    // Leave keeper-tip SOL in the fee pool, then age the account past the inactivity window.
+    let payer = test_f.payer();
+    let top_up = user_f
+        .make_top_up_rebalance_fee_pool_ix(payer, 1_000_000)
+        .await;
+    {
+        let blockhash = test_f.get_latest_blockhash().await;
+        let ctx = test_f.context.borrow_mut();
+        let tx =
+            Transaction::new_signed_with_payer(&[top_up], Some(&payer), &[&ctx.payer], blockhash);
+        ctx.banks_client.process_transaction(tx).await?;
+    }
+    {
+        let ctx = test_f.context.borrow_mut();
+        let mut clock: Clock = ctx.banks_client.get_sysvar().await?;
+        clock.unix_timestamp += 60 * 24 * 60 * 60 + 1;
+        ctx.set_sysvar(&clock);
+    }
 
     let global_fee_wallet = test_f.marginfi_group.fee_wallet;
     let res = user_f.try_admin_close_account(global_fee_wallet).await;

--- a/programs/marginfi/tests/user_actions/rebalance.rs
+++ b/programs/marginfi/tests/user_actions/rebalance.rs
@@ -1504,8 +1504,9 @@ async fn rebalance_rejects_omitting_an_allowlisted_bank() -> anyhow::Result<()> 
 async fn rebalance_rejects_a_move_to_less_than_the_best_venue() -> anyhow::Result<()> {
     let f = setup(I80F48::from_num(0.0001), 0).await?;
     let dst2 = f.add_second_dst().await?;
-    // Dilute the second destination so the first strictly dominates it.
-    drive_utilization(&f.test_f, &dst2, 400.0, 200.0).await?;
+    // Give the second destination more depth at a lower utilization (600 borrowed of 2000), so the
+    // first still pays more after either deposit.
+    drive_utilization(&f.test_f, &dst2, 100.0, 200.0).await?;
 
     let ref_banks = vec![
         f.bank_meta(f.src_bank_f.key),
@@ -2026,8 +2027,9 @@ async fn rebalance_rejects_injected_unreferenced_balance() -> anyhow::Result<()>
 async fn rebalance_rejects_passing_over_a_higher_rate_bank() -> anyhow::Result<()> {
     let f = setup(I80F48::from_num(0.0001), 0).await?;
     let dst2 = f.add_second_dst().await?;
-    // Separate the two destinations' rates so one strictly dominates.
-    drive_utilization(&f.test_f, &dst2, 400.0, 200.0).await?;
+    // Give the second destination more depth at a lower utilization (600 borrowed of 2000), so the
+    // first still pays more after either deposit.
+    drive_utilization(&f.test_f, &dst2, 100.0, 200.0).await?;
 
     let ref_banks = vec![
         f.bank_meta(f.src_bank_f.key),
@@ -2052,14 +2054,106 @@ async fn rebalance_rejects_passing_over_a_higher_rate_bank() -> anyhow::Result<(
     Ok(())
 }
 
+/// Every other bank is priced with the move's tokens added to its own inflow: sending both chunks
+/// to one of two identical banks is rejected: the second chunk would earn more in the other.
+#[tokio::test]
+async fn rebalance_judges_a_repeated_destination_against_its_untouched_twin() -> anyhow::Result<()>
+{
+    let f = setup(I80F48::from_num(0.0001), 0).await?;
+    let dst2 = f.add_second_dst().await?;
+    let chunk = 200.0;
+    let ref_banks = vec![
+        f.bank_meta(f.src_bank_f.key),
+        f.bank_meta(f.dst_bank_f.key),
+        f.bank_meta(dst2.key),
+    ];
+    let doubled = f
+        .user
+        .make_rebalance_start_ix(
+            ref_banks.clone(),
+            vec![rebalance_move(0, 1, chunk), rebalance_move(0, 1, chunk)],
+            0,
+            f.order_pda,
+            f.record_pda,
+            f.keeper.pubkey(),
+            f.keeper.pubkey(),
+        )
+        .await;
+    let res = f.process(&[doubled]).await;
+    assert_custom_error!(res.unwrap_err(), MarginfiError::RebalanceNotBestVenue);
+
+    // One chunk to each twin passes: each twin is priced with the other's chunk already counted.
+    let old_src = f.asset_shares(f.src_bank_f.key).await;
+    let start_ix = f
+        .user
+        .make_rebalance_start_ix(
+            ref_banks.clone(),
+            vec![rebalance_move(0, 1, chunk), rebalance_move(0, 2, chunk)],
+            0,
+            f.order_pda,
+            f.record_pda,
+            f.keeper.pubkey(),
+            f.keeper.pubkey(),
+        )
+        .await;
+    let withdraw_ix = f
+        .user
+        .make_withdraw_ix_with_authority(
+            f.keeper_usdc,
+            &f.src_bank_f,
+            2.0 * chunk,
+            None,
+            f.keeper.pubkey(),
+        )
+        .await;
+    let deposit_dst1 = f
+        .user
+        .make_deposit_ix_with_authority(
+            f.keeper_usdc,
+            &f.dst_bank_f,
+            chunk,
+            None,
+            f.keeper.pubkey(),
+        )
+        .await;
+    let deposit_dst2 = f
+        .user
+        .make_deposit_ix_with_authority(f.keeper_usdc, &dst2, chunk, None, f.keeper.pubkey())
+        .await;
+    // The source keeps its remainder, so it stays in the post-move observation set.
+    let end_ix = f
+        .user
+        .make_rebalance_end_ix(
+            ref_banks,
+            vec![],
+            f.order_pda,
+            f.record_pda,
+            f.keeper.pubkey(),
+        )
+        .await;
+    f.process(&[start_ix, withdraw_ix, deposit_dst1, deposit_dst2, end_ix])
+        .await?;
+
+    let dst1_after = f.asset_shares(f.dst_bank_f.key).await;
+    let dst2_after = f.asset_shares(dst2.key).await;
+    assert_eq!(dst1_after, dst2_after, "each twin took one chunk");
+    assert_eq!(
+        f.asset_shares(f.src_bank_f.key).await + dst1_after + dst2_after,
+        old_src,
+        "same-mint shares conserved"
+    );
+    Ok(())
+}
+
 /// The dominant destination has no headroom left, so the move routes past it into the lower-rate
 /// bank.
 #[tokio::test]
 async fn rebalance_allows_overflow_past_a_full_higher_rate_bank() -> anyhow::Result<()> {
     let f = setup(I80F48::from_num(0.0001), 0).await?;
     let dst2 = f.add_second_dst().await?;
-    // Dilute the second destination so the first strictly dominates it on rate.
-    drive_utilization(&f.test_f, &dst2, 400.0, 200.0).await?;
+    // Give the second destination more depth at a lower utilization (600 borrowed of 2000), so the
+    // first still pays more after either deposit.
+    drive_utilization(&f.test_f, &dst2, 100.0, 200.0).await?;
     // Cap the dominant destination under its current assets, leaving it zero headroom.
     f.dst_bank_f
         .update_config(
@@ -2236,6 +2330,35 @@ async fn rebalance_rejects_empty_moves() -> anyhow::Result<()> {
         .await;
     let res = f.process(&[start_ix]).await;
     assert_custom_error!(res.unwrap_err(), MarginfiError::IllegalBalanceState);
+    Ok(())
+}
+
+/// A bank may not be both a source and a destination in one execution.
+#[tokio::test]
+async fn rebalance_rejects_a_bank_that_is_both_source_and_destination() -> anyhow::Result<()> {
+    let f = setup(I80F48::from_num(0.0001), 0).await?;
+    let dst2 = f.add_second_dst().await?;
+    let start_ix = f
+        .user
+        .make_rebalance_start_ix(
+            vec![
+                f.bank_meta(f.src_bank_f.key),
+                f.bank_meta(f.dst_bank_f.key),
+                f.bank_meta(dst2.key),
+            ],
+            vec![rebalance_move(0, 1, 500.0), rebalance_move(1, 2, 500.0)],
+            0,
+            f.order_pda,
+            f.record_pda,
+            f.keeper.pubkey(),
+            f.keeper.pubkey(),
+        )
+        .await;
+    let res = f.process(&[start_ix]).await;
+    assert_custom_error!(
+        res.unwrap_err(),
+        MarginfiError::RebalanceBankSourceAndDestination
+    );
     Ok(())
 }
 
@@ -2791,16 +2914,143 @@ async fn rebalance_consolidate_rejected_when_destination_makes_unhealthy() -> an
     Ok(())
 }
 
-/// A native bank's cached rate ignores the incoming deposit, so the start gate reads the destination
-/// undiluted and the end gate is what catches a move whose own deposit erases the advantage.
+/// The start gate prices a native destination as it would stand after the move's own deposit.
 #[tokio::test]
 async fn rebalance_rejects_a_move_whose_deposit_erases_the_improvement() -> anyhow::Result<()> {
-    // dst stands at util 0.5 (lending rate 0.300) and clears 0 + 0.1 at start. The arriving 1000
-    // halves its utilization to 0.25 (lending rate 0.075), which no longer clears the margin.
+    // dst sits at 50% utilization (lending rate 0.300), clearing the 0.1 margin over src's 0. The
+    // arriving 1000 halves that to 25% (lending rate 0.075), which no longer clears it.
     let f = setup(I80F48::from_num(0.1), 0).await?;
     let ixs = f.build_sandwich(f.src_bank_f.key, f.dst_bank_f.key).await;
     let res = f.process(&ixs).await;
+    assert_custom_error!(res.unwrap_err(), MarginfiError::RebalanceNotImproving);
+    Ok(())
+}
+
+/// The end gate prices the destination as it really stands, so a keeper cannot declare a small
+/// move and land a large one to dodge the dilution.
+#[tokio::test]
+async fn rebalance_end_rejects_a_deposit_beyond_the_declared_move() -> anyhow::Result<()> {
+    // A declared 1 USDC leaves dst near 50% utilization, clear of the 0.1 margin; the 1000 the legs
+    // actually move halve that (lending rate 0.075).
+    let f = setup(I80F48::from_num(0.1), 0).await?;
+    let ref_banks = vec![f.bank_meta(f.src_bank_f.key), f.bank_meta(f.dst_bank_f.key)];
+    let start_ix = f
+        .user
+        .make_rebalance_start_ix(
+            ref_banks.clone(),
+            vec![rebalance_move(0, 1, 1.0)],
+            0,
+            f.order_pda,
+            f.record_pda,
+            f.keeper.pubkey(),
+            f.keeper.pubkey(),
+        )
+        .await;
+    let withdraw_ix = f
+        .user
+        .make_withdraw_ix_with_authority(
+            f.keeper_usdc,
+            &f.src_bank_f,
+            DEPOSIT_USDC,
+            Some(true),
+            f.keeper.pubkey(),
+        )
+        .await;
+    let deposit_ix = f
+        .user
+        .make_deposit_ix_with_authority(
+            f.keeper_usdc,
+            &f.dst_bank_f,
+            DEPOSIT_USDC,
+            None,
+            f.keeper.pubkey(),
+        )
+        .await;
+    let end_ix = f
+        .user
+        .make_rebalance_end_ix(
+            ref_banks,
+            vec![f.src_bank_f.key],
+            f.order_pda,
+            f.record_pda,
+            f.keeper.pubkey(),
+        )
+        .await;
+    let res = f
+        .process(&[start_ix, withdraw_ix, deposit_ix, end_ix])
+        .await;
     assert_custom_error!(res.unwrap_err(), MarginfiError::RebalanceOvershoot);
+    Ok(())
+}
+
+/// Two moves into one destination are priced as one deposit of their combined amount.
+#[tokio::test]
+async fn rebalance_prices_a_destination_at_its_total_inflow() -> anyhow::Result<()> {
+    // Half the position leaves dst at 33% utilization (lending rate 0.133), clearing the 0.1
+    // margin; the whole position leaves it at 25% (0.075). Two halves are judged as the whole.
+    let f = setup(I80F48::from_num(0.1), 0).await?;
+    let half = DEPOSIT_USDC / 2.0;
+    let ref_banks = vec![f.bank_meta(f.src_bank_f.key), f.bank_meta(f.dst_bank_f.key)];
+    let split = f
+        .user
+        .make_rebalance_start_ix(
+            ref_banks.clone(),
+            vec![rebalance_move(0, 1, half), rebalance_move(0, 1, half)],
+            0,
+            f.order_pda,
+            f.record_pda,
+            f.keeper.pubkey(),
+            f.keeper.pubkey(),
+        )
+        .await;
+    let res = f.process(&[split]).await;
+    assert_custom_error!(res.unwrap_err(), MarginfiError::RebalanceNotImproving);
+
+    let old_src = f.asset_shares(f.src_bank_f.key).await;
+    let start_ix = f
+        .user
+        .make_rebalance_start_ix(
+            ref_banks.clone(),
+            vec![rebalance_move(0, 1, half)],
+            0,
+            f.order_pda,
+            f.record_pda,
+            f.keeper.pubkey(),
+            f.keeper.pubkey(),
+        )
+        .await;
+    let withdraw_ix = f
+        .user
+        .make_withdraw_ix_with_authority(
+            f.keeper_usdc,
+            &f.src_bank_f,
+            half,
+            None,
+            f.keeper.pubkey(),
+        )
+        .await;
+    let deposit_ix = f
+        .user
+        .make_deposit_ix_with_authority(f.keeper_usdc, &f.dst_bank_f, half, None, f.keeper.pubkey())
+        .await;
+    // The source keeps its other half, so it stays in the post-move observation set.
+    let end_ix = f
+        .user
+        .make_rebalance_end_ix(
+            ref_banks,
+            vec![],
+            f.order_pda,
+            f.record_pda,
+            f.keeper.pubkey(),
+        )
+        .await;
+    f.process(&[start_ix, withdraw_ix, deposit_ix, end_ix])
+        .await?;
+
+    let src_after = f.asset_shares(f.src_bank_f.key).await;
+    let dst_after = f.asset_shares(f.dst_bank_f.key).await;
+    assert_eq!(src_after, dst_after, "the position split into equal halves");
+    assert_eq!(src_after + dst_after, old_src, "same-mint shares conserved");
     Ok(())
 }
 

--- a/test-utils/src/marginfi_account.rs
+++ b/test-utils/src/marginfi_account.rs
@@ -2612,6 +2612,7 @@ impl MarginfiAccountFixture {
                 group: marginfi_account.group,
                 marginfi_account: self.key,
                 global_fee_wallet,
+                rebalance_fee_pool: self.rebalance_fee_pool_pda(),
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::AdminCloseAccount {}.data(),

--- a/type-crate/src/types/rebalance.rs
+++ b/type-crate/src/types/rebalance.rs
@@ -85,10 +85,10 @@ pub struct RebalanceRefBank {
 }
 
 // A declared token move from `src_index` to `dst_index` (indices into `RebalanceRecord.ref_banks`),
-// of `amount` underlying tokens. The keeper declares these; `start_rebalance` requires each move's
-// destination rate to beat its source by the order's margin, and `end_rebalance` re-checks the
-// destination is not worse after market impact and reconciles the amounts against the observed
-// per-bank token deltas.
+// of `amount` underlying tokens. The keeper declares these; `start_rebalance` requires each
+// move's destination rate, taken after every declared deposit into that bank, to beat its source
+// by the order's margin, and `end_rebalance` re-checks the destination is not worse after market
+// impact and reconciles the amounts against the observed per-bank token deltas.
 assert_struct_size!(RebalanceMove, 24);
 assert_struct_align!(RebalanceMove, 8);
 #[repr(C)]


### PR DESCRIPTION
## Fixes 

 1. Native bank rates now are computed from live assets and liabilities at the post-deposit utilization, replacing the cached pre-deposit rate in the start-side improvement and best-venue checks
  2. Rates are evaluated in aggregate: each destination at its total declared inflow, and each competing bank at its own inflow plus the move, so chunked or consolidated moves cannot pass a best-venue check their total would fail
  3. A bank may not be both a source and a destination within one execution, rejected with the new RebalanceBankSourceAndDestination error